### PR TITLE
fix #2

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,7 +13,6 @@ import (
 	"github.com/meian/atgo/flags"
 	"github.com/meian/atgo/http"
 	"github.com/meian/atgo/http/cookie"
-	"github.com/meian/atgo/http/cookiestore"
 	"github.com/meian/atgo/http/roundtrippers"
 	"github.com/meian/atgo/io"
 	"github.com/meian/atgo/logs"
@@ -120,7 +119,7 @@ func initializeHTTPClient(cmd *cobra.Command) error {
 	if exists {
 		if time.Since(modtime) <= 24*time.Hour {
 			url := url.URL("", nil, nil)
-			if err := cookiestore.Load(url, cfile, jar); err != nil {
+			if err := cookie.LoadFrom(url, cfile, jar); err != nil {
 				logger.Error(err.Error())
 				return errors.New("failed to load cookie")
 			}
@@ -147,7 +146,7 @@ func terminateHTTPClient(cmd *cobra.Command) {
 	}
 	cfile, _, _ := workspace.CookieFile()
 	logger = logger.With("cookie file", cfile)
-	if err := cookiestore.Save(url.URL("", nil, nil), cfile, client.Jar); err != nil {
+	if err := cookie.SaveTo(url.URL("", nil, nil), cfile, client.Jar); err != nil {
 		logger.With("error", err.Error()).Warn("failed to store cookies")
 		return
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/meian/atgo/database"
 	"github.com/meian/atgo/flags"
 	"github.com/meian/atgo/http"
+	"github.com/meian/atgo/http/cookie"
 	"github.com/meian/atgo/http/cookiestore"
 	"github.com/meian/atgo/http/roundtrippers"
 	"github.com/meian/atgo/io"
@@ -108,7 +109,11 @@ func initializeDatabase(cmd *cobra.Command) error {
 
 func initializeHTTPClient(cmd *cobra.Command) error {
 	logger := logs.FromContext(cmd.Context())
-	jar, _ := cookiejar.New(nil)
+	jopt := cookie.JarOption{
+		IgnorePaths: []string{url.HomePath},
+	}
+	baseJar, _ := cookiejar.New(nil)
+	jar := cookie.NewJar(baseJar, jopt)
 	cfile, modtime, exists := workspace.CookieFile()
 	logger = logger.With("cookie file", cfile).With("modtime", modtime)
 

--- a/http/client.go
+++ b/http/client.go
@@ -2,10 +2,9 @@ package http
 
 import (
 	"net/http"
-	"net/http/cookiejar"
 )
 
-func NewClient(transport http.RoundTripper, jar *cookiejar.Jar) *http.Client {
+func NewClient(transport http.RoundTripper, jar http.CookieJar) *http.Client {
 	return &http.Client{
 		Transport: transport,
 		Jar:       jar,

--- a/http/cookie/file.go
+++ b/http/cookie/file.go
@@ -1,4 +1,4 @@
-package cookiestore
+package cookie
 
 import (
 	"encoding/gob"
@@ -7,7 +7,7 @@ import (
 	"os"
 )
 
-func Load(url *url.URL, file string, jar http.CookieJar) error {
+func LoadFrom(url *url.URL, file string, jar http.CookieJar) error {
 	f, err := os.Open(file)
 	if err != nil {
 		return nil
@@ -21,7 +21,7 @@ func Load(url *url.URL, file string, jar http.CookieJar) error {
 	return nil
 }
 
-func Save(url *url.URL, file string, jar http.CookieJar) error {
+func SaveTo(url *url.URL, file string, jar http.CookieJar) error {
 	cookies := jar.Cookies(url)
 	if len(cookies) == 0 {
 		return nil

--- a/http/cookie/jar.go
+++ b/http/cookie/jar.go
@@ -1,0 +1,42 @@
+package cookie
+
+import (
+	"net/http"
+	"net/url"
+	"slices"
+)
+
+type JarOption struct {
+	IgnorePaths []string
+}
+
+type Jar struct {
+	jar    http.CookieJar
+	option JarOption
+}
+
+var _ http.CookieJar = &Jar{}
+
+func NewJar(jar http.CookieJar, opt JarOption) *Jar {
+	return &Jar{
+		jar:    jar,
+		option: opt,
+	}
+
+}
+
+// Cookies implements http.CookieJar.
+func (j *Jar) Cookies(u *url.URL) []*http.Cookie {
+	if u == nil {
+		return nil
+	}
+	if slices.Contains(j.option.IgnorePaths, u.Path) {
+		return nil
+	}
+	return j.jar.Cookies(u)
+}
+
+// SetCookies implements http.CookieJar.
+func (j *Jar) SetCookies(u *url.URL, cookies []*http.Cookie) {
+	j.jar.SetCookies(u, cookies)
+}

--- a/http/cookiestore/cookie.go
+++ b/http/cookiestore/cookie.go
@@ -22,12 +22,7 @@ func Load(url *url.URL, file string, jar http.CookieJar) error {
 }
 
 func Save(url *url.URL, file string, jar http.CookieJar) error {
-	var cookies []*http.Cookie
-	for _, cookie := range jar.Cookies(url) {
-		if cookie.MaxAge > 0 {
-			cookies = append(cookies, cookie)
-		}
-	}
+	cookies := jar.Cookies(url)
 	if len(cookies) == 0 {
 		return nil
 	}


### PR DESCRIPTION
- Cookieの保存対象をMaxAgeを考慮せずに全て保存するように変更
- `/home` はCookieを送信しないようにした
    - `/login`の前に `/home` を踏ませることでCSRFトークンを取得しているが、ログイン時にログイン済セッションのCookieは邪魔になるため