### PR TITLE
fix #2

### DIFF
--- a/crawler/home.go
+++ b/crawler/home.go
@@ -2,11 +2,12 @@ package crawler
 
 import (
 	"context"
-	"net/http"
+	gohttp "net/http"
 
 	"github.com/meian/atgo/crawler/requests"
 	"github.com/meian/atgo/crawler/responses"
 	"github.com/meian/atgo/csrf"
+	"github.com/meian/atgo/http"
 	"github.com/meian/atgo/logs"
 	"github.com/meian/atgo/url"
 	"github.com/pkg/errors"
@@ -16,12 +17,13 @@ type Home struct {
 	crawler *Crawler
 }
 
-func NewHome(client *http.Client) *Home {
+func NewHome(client *gohttp.Client) *Home {
 	crawler := NewCrawler(url.HomePath).WithClient(client)
 	return &Home{crawler: crawler}
 }
 
 func (c *Home) Do(ctx context.Context, req *requests.Home) (*responses.Home, error) {
+	ctx = http.ContextWithSkipWait(ctx)
 	doc, err := c.crawler.DocumentGet(ctx, req)
 	if err != nil {
 		logs.FromContext(ctx).Error(err.Error())

--- a/http/context.go
+++ b/http/context.go
@@ -7,11 +7,13 @@ import (
 
 type key string
 
-const clientKey key = "client"
+const (
+	clientKey   key = "client"
+	skipWaitKey key = "skipWait"
+)
 
 func ClientFromContext(ctx context.Context) *http.Client {
-	v := ctx.Value(clientKey)
-	c, ok := v.(*http.Client)
+	c, ok := ctx.Value(clientKey).(*http.Client)
 	if !ok {
 		return http.DefaultClient
 	}
@@ -20,4 +22,16 @@ func ClientFromContext(ctx context.Context) *http.Client {
 
 func ContextWithClient(ctx context.Context, client *http.Client) context.Context {
 	return context.WithValue(ctx, clientKey, client)
+}
+
+func IsSkipWait(ctx context.Context) bool {
+	s, ok := ctx.Value(skipWaitKey).(bool)
+	if !ok {
+		return false
+	}
+	return s
+}
+
+func ContextWithSkipWait(ctx context.Context) context.Context {
+	return context.WithValue(ctx, skipWaitKey, true)
 }

--- a/logs/logger.go
+++ b/logs/logger.go
@@ -30,7 +30,7 @@ func New(out io.Writer, level slog.Level) *slog.Logger {
 	handler := clog.New(
 		clog.WithWriter(out),
 		clog.WithLevel(level),
-		clog.WithTimeFmt("2006-01-02 15:04:05"),
+		clog.WithTimeFmt("2006-01-02 15:04:05.999"),
 		clog.WithColorMap(colorDefault),
 		clog.WithPrinter(clog.IndentPrinter),
 		clog.WithSource(true),


### PR DESCRIPTION
- `POST /login` とその前段の `GET /home` はリクエスト間の待機の対象外にした
    - 呼び出し時に待機しないようにしたのと前回待機時刻として保存しないようにした
- レスポンスが 302(Status Found) の時は次のリクエストは待機されないようにした
- 待機時間をある程度正確に計測するため、ログの時刻をミリ秒まで出力するようにした
