### PR TITLE
#13 ビルドとリリースのためのGitHub Actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,105 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        goos: [linux, windows, darwin]
+        arch: [amd64, arm64]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: './go.mod'
+
+      - name: Set environment
+        run: |
+          key='${{matrix.goos}}_${{matrix.arch}}'
+          an="artifact_${key}"
+          fn="atgo_${key}"
+          if [ '${{matrix.goos}}' == 'windows' ]; then
+            fn=${fn}.exe
+          fi
+          cat << ENV >> $GITHUB_ENV
+          APP_VERSION=${GITHUB_REF#refs/tags/}
+          ARTIFACT_NAME=${an}
+          BIN_PATH=out/${fn}
+          ENV
+
+      - name: Download go modules
+        run: go mod download
+
+      - name: Go build
+        run: |
+          ROOT_PKG=$(go list .)
+          COMMIT_SHA=$(echo ${{github.sha}} | cut -c1-10)
+          FLAGS="-X $ROOT_PKG/flags.Version=$APP_VERSION -X $ROOT_PKG/flags.CommitSHA=$COMMIT_SHA"
+          GOOS=${{matrix.goos}} GOARCH=${{matrix.arch}} go build -ldflags "$FLAGS" -o $BIN_PATH .
+        shell: bash
+
+      - name: Upload assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{env.ARTIFACT_NAME}}
+          path: ${{env.BIN_PATH}}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download (linux - amd64)
+        uses: actions/download-artifact@v4
+        with:
+          name: artifact_linux_amd64
+          path: releases
+
+      - name: Download (linux - arm64)
+        uses: actions/download-artifact@v4
+        with:
+          name: artifact_linux_arm64
+          path: releases
+
+      - name: Download (windows - amd64)
+        uses: actions/download-artifact@v4
+        with:
+          name: artifact_windows_amd64
+          path: releases
+
+      - name: Download (windows - arm64)
+        uses: actions/download-artifact@v4
+        with:
+          name: artifact_windows_arm64
+          path: releases
+
+      - name: Download (darwin - amd64)
+        uses: actions/download-artifact@v4
+        with:
+          name: artifact_darwin_amd64
+          path: releases
+
+      - name: Download (darwin - arm64)
+        uses: actions/download-artifact@v4
+        with:
+          name: artifact_darwin_arm64
+          path: releases
+
+      - name: Add execute permission
+        run: |
+          chmod +x releases/atgo_linux*
+          chmod +x releases/atgo_darwin*
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          token: ${{secrets.RELEASE_TOKEN}}
+          draft: true
+          files: releases/*

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"github.com/meian/atgo/database"
+	"github.com/meian/atgo/flags"
+	"github.com/meian/atgo/http/cookie"
+	"github.com/meian/atgo/io"
+	"github.com/meian/atgo/logs"
+	"github.com/meian/atgo/tmpl"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var versionFlag struct {
+	Long bool
+}
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show app version",
+	Long:  `Show app version.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !versionFlag.Long {
+			v := flags.Version
+			if v == "" {
+				v = "no_version"
+			}
+			cmd.Println(v)
+			return nil
+		}
+		model := VersionOutputModel{
+			Version:     flags.Version,
+			CommitSHA:   flags.CommitSHA,
+			Description: rootCmd.Short,
+			FlagsPkg:    flags.Package(),
+		}
+
+		ctx := cmd.Context()
+		logger := logs.FromContext(ctx)
+
+		tname := "version"
+		t := tmpl.CmdTemplate(tname)
+		w := io.OutFromContext(ctx)
+		if err := t.Execute(w, model); err != nil {
+			logger.With("template name", tname).Error(err.Error())
+			return errors.New("failed to execute template")
+		}
+		return nil
+	},
+}
+
+func init() {
+	cookie.IgnoreLoad(versionCmd.CommandPath)
+	cookie.IgnoreSave(versionCmd.CommandPath)
+	database.Ignore(versionCmd.CommandPath)
+	rootCmd.AddCommand(versionCmd)
+	versionCmd.Flags().BoolVar(&versionFlag.Long, "long", false, "Show version and descriptions")
+}
+
+type VersionOutputModel struct {
+	Version     string
+	CommitSHA   string
+	Description string
+	FlagsPkg    string
+}

--- a/flags/ldflags.go
+++ b/flags/ldflags.go
@@ -1,11 +1,15 @@
 package flags
 
-var (
-	Version string
+import (
+	"reflect"
 )
 
-func init() {
-	if Version == "" {
-		Version = "no version, please set with ldflags"
-	}
+var (
+	Version   string
+	CommitSHA string
+)
+
+func Package() string {
+	type tip int
+	return reflect.TypeOf(tip(0)).PkgPath()
 }

--- a/tmpl/templates/cmd/version.tmpl
+++ b/tmpl/templates/cmd/version.tmpl
@@ -1,0 +1,7 @@
+atgo
+{{- if .Version }} {{ .Version }}{{ else }} (No Version){{ end }}
+{{- if .CommitSHA }} (commit SHA: {{ .CommitSHA }}){{ end }}
+{{ .Description }}
+{{ if not .Version -}}
+Version is not set, please set the version at build with -ldflags '-X {{ .FlagsPkg }}.Version=vx.x.x -X {{ .FlagsPkg }}.CommitSHA=xxxxxx'
+{{ end -}}


### PR DESCRIPTION
タグ生成時にリリースをドラフトで作成するためのGitHub Actionsとバージョン等の情報を表示するためのコマンドを追加しました。

- linux / windows / mac についてそれぞれamd64/arm64アーキテクチャでビルドバイナリを生成
- そのバージョンとしてビルドされているか、バージョン番号(tag)とコミットのSHAを埋め込む処理を追加
- バージョンを表示するコマンドを追加
- タグプッシュでCIを実行し、それぞれのバイナリを含むリリースを作詞する処理を追加
    - リリースノート手動でを書いてから公開するので非公開・ドラフトとして登録

~~https://github.com/meian/atgo/issues/13#issuecomment-2088315723 の問題が解決してから改めて対応する~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - アプリケーションのバージョン情報を表示する機能を追加しました。バージョン番号、コミットSHA、説明詳細が含まれます。
  - GitHub Actionsワークフローを用いたリリースプロセスを設定しました。これにより、異なるプラットフォーム向けのビルドおよびリリースが自動化されます。

- **ドキュメント**
  - バージョン情報を表示するための新しいテンプレートファイルを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->