### PR TITLE
デフォルトログレベルをnone(何も出力しない)に変更した

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,8 @@
 		}
 	},
 	"containerEnv": {
-		"ATGO_WORKSPACE": "/workspace"
+		"ATGO_WORKSPACE": "/workspace",
+		"ATGO_DEFAULT_LOG_LEVEL": "info"
 	},
 	"postCreateCommand": "./.devcontainer/postCommand.sh vscode",
 	"mounts": [

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/meian/atgo/config"
 	"github.com/meian/atgo/database"
-	"github.com/meian/atgo/flags"
 	"github.com/meian/atgo/http"
 	"github.com/meian/atgo/http/cookie"
 	"github.com/meian/atgo/http/roundtrippers"
@@ -68,7 +67,7 @@ func initializeOutput(cmd *cobra.Command) error {
 // initializeLogging はロガーの初期化を行う
 // グローバルに設定されたフラグによって出力されるレベルを変更してロガーを作成する
 func initializeLogging(cmd *cobra.Command) error {
-	level, err := logs.ParseLevel(flags.DefaultLogLevel)
+	level, err := logs.ParseLevel(config.Config.DefaultLogLevel)
 	if err != nil {
 		return err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -1,13 +1,16 @@
 package config
 
 import (
+	"log/slog"
 	"reflect"
 
+	"github.com/meian/atgo/logs"
 	"github.com/spf13/viper"
 )
 
 type config struct {
-	Workspace string `mapstructure:"workspace" default:"."`
+	Workspace       string `mapstructure:"workspace" default:"."`
+	DefaultLogLevel string `mapstructure:"default_log_level" default:"none"`
 }
 
 var Config config
@@ -17,7 +20,12 @@ func Inititalize() {
 	viper.SetEnvPrefix("ATGO")
 	viper.AutomaticEnv()
 	if err := viper.Unmarshal(&Config); err != nil {
-		panic(err)
+		slog.Warn("failed to read config from environment: %v", err)
+		return
+	}
+	_, err := logs.ParseLevel(Config.DefaultLogLevel)
+	if err != nil {
+		Config.DefaultLogLevel = "none"
 	}
 }
 

--- a/flags/ldflags.go
+++ b/flags/ldflags.go
@@ -1,19 +1,11 @@
 package flags
 
-import (
-	"log/slog"
-)
-
 var (
-	Version         string
-	DefaultLogLevel string
+	Version string
 )
 
 func init() {
 	if Version == "" {
 		Version = "no version, please set with ldflags"
-	}
-	if DefaultLogLevel == "" {
-		DefaultLogLevel = slog.LevelInfo.String()
 	}
 }

--- a/logs/level.go
+++ b/logs/level.go
@@ -2,6 +2,7 @@ package logs
 
 import (
 	"log/slog"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -16,25 +17,20 @@ const (
 
 var (
 	levelLookup map[string]slog.Level
-	textLookup  map[slog.Level]string
 )
 
 func init() {
 	levelLookup = map[string]slog.Level{
-		"NONE":  LevelNone,
-		"ERROR": LevelError,
-		"WARN":  LevelWarn,
-		"INFO":  LevelInfo,
-		"DEBUG": LevelDebug,
-	}
-	textLookup = make(map[slog.Level]string, len(levelLookup))
-	for k, v := range levelLookup {
-		textLookup[v] = k
+		"none":  LevelNone,
+		"error": LevelError,
+		"warn":  LevelWarn,
+		"info":  LevelInfo,
+		"debug": LevelDebug,
 	}
 }
 
 func ParseLevel(s string) (slog.Level, error) {
-	level, ok := levelLookup[s]
+	level, ok := levelLookup[strings.ToLower(s)]
 	if !ok {
 		return LevelNone, errors.Errorf("invalid log level: %s", s)
 	}


### PR DESCRIPTION
- `ATGO_DEFAULT_LOG_LEVEL` 環境変数の設定がない環境ではデフォルトでログが出力されないようにした
- devcontainerでは `ATGO_DEFAULT_LOG_LEVEL=info` とすることで以前同様にログが出力されるようにした


closes #17 