### PR TITLE
#11 Add feature for skipping store and load cookies

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -8,6 +8,7 @@ import (
 	"github.com/meian/atgo/crawler"
 	"github.com/meian/atgo/crawler/requests"
 	"github.com/meian/atgo/http"
+	"github.com/meian/atgo/http/cookie"
 	"github.com/meian/atgo/logs"
 	"github.com/meian/atgo/url"
 	"github.com/meian/atgo/workspace"
@@ -93,5 +94,6 @@ func tryLogin(ctx context.Context, username, password string) error {
 }
 
 func init() {
+	cookie.IgnoreLoad(authCmd.CommandPath)
 	rootCmd.AddCommand(authCmd)
 }

--- a/cmd/authClear.go
+++ b/cmd/authClear.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
+	"github.com/meian/atgo/http/cookie"
 	"github.com/meian/atgo/io"
 	"github.com/meian/atgo/workspace"
 	"github.com/pkg/errors"
@@ -14,19 +16,47 @@ var authClearCmd = &cobra.Command{
 	Short: "Clear stored credential",
 	Long:  `Clear stored credential in your local environment.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		file := workspace.CredentialFile()
-		if !io.FileExists(file) {
-			cmd.Println("No credential is stored.")
-			return nil
+		credError := removeCredential(cmd)
+		cookieError := removeCookie(cmd)
+		if credError != nil {
+			if cookieError != nil {
+				return fmt.Errorf("%w / %w", credError, cookieError)
+			}
+			return credError
 		}
-		if err := os.Remove(file); err != nil {
-			return errors.Wrap(err, "failed to remove credential file")
-		}
-		cmd.Println("Credential is removed.")
-		return nil
+		return cookieError
 	},
 }
 
+// TODO: usecase化
+func removeCredential(cmd *cobra.Command) error {
+	file := workspace.CredentialFile()
+	if !io.FileExists(file) {
+		cmd.Println("No credential is stored.")
+		return nil
+	}
+	if err := os.Remove(file); err != nil {
+		return errors.Wrap(err, "failed to remove credential file")
+	}
+	cmd.Println("Credential is removed.")
+	return nil
+}
+
+func removeCookie(cmd *cobra.Command) error {
+	file, _, exists := workspace.CookieFile()
+	if !exists {
+		cmd.Println("No cookie is stored.")
+		return nil
+	}
+	if err := os.Remove(file); err != nil {
+		return errors.Wrap(err, "failed to remove cookie file")
+	}
+	cmd.Println("Cookie is removed.")
+	return nil
+
+}
+
 func init() {
+	cookie.IgnoreSave(authClearCmd.CommandPath)
 	authCmd.AddCommand(authClearCmd)
 }

--- a/cmd/authVerify.go
+++ b/cmd/authVerify.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/meian/atgo/auth"
+	"github.com/meian/atgo/http/cookie"
 	"github.com/meian/atgo/io"
 	"github.com/meian/atgo/logs"
 	"github.com/meian/atgo/workspace"
@@ -35,5 +36,6 @@ var authVerifyCmd = &cobra.Command{
 }
 
 func init() {
+	cookie.IgnoreLoad(authVerifyCmd.CommandPath)
 	authCmd.AddCommand(authVerifyCmd)
 }

--- a/http/cookie/file.go
+++ b/http/cookie/file.go
@@ -7,6 +7,11 @@ import (
 	"os"
 )
 
+var (
+	ignoreLoads []func() string
+	ignoreSaves []func() string
+)
+
 func LoadFrom(url *url.URL, file string, jar http.CookieJar) error {
 	f, err := os.Open(file)
 	if err != nil {
@@ -35,4 +40,30 @@ func SaveTo(url *url.URL, file string, jar http.CookieJar) error {
 		return err
 	}
 	return nil
+}
+
+func IgnoreLoad(pathFunc func() string) {
+	ignoreLoads = append(ignoreLoads, pathFunc)
+}
+
+func ShouldLoad(path string) bool {
+	for _, p := range ignoreLoads {
+		if p() == path {
+			return false
+		}
+	}
+	return true
+}
+
+func IgnoreSave(pathFunc func() string) {
+	ignoreSaves = append(ignoreSaves, pathFunc)
+}
+
+func ShouldSave(path string) bool {
+	for _, p := range ignoreSaves {
+		if p() == path {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
- 起動時のファイルからのCookie情報読み込みと事後の保存をコマンドごとに制御する仕組みを追加した
- `auth` / `auth verify` でCookieの読み込みを行わないようにした
- `auth clear` でCookieの保存を行わないようにした
- `auth clear` でcredentialと合わせてCookieも削除するようにした

`/home` が常にCookieの取得ができないという状況だとログイン後の画面遷移でHTMLからのログインチェックが行えないことがわかったため、コマンド単位で個別にCookieの初期ロードと事後保存を無視できるようにしました。

それぞれ以下の理由で設定しています。

- `auth` / `auth verify` は処理途中でログインを行うものであり、すでにログイン済のCookieがあると再ログインに失敗するため読み込みを行わない
- `auth clear` は認証情報と合わせてCookieを削除する処理なので保存を行わない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 認証、認証解除、認証確認コマンドにクッキーの読み込みと保存を無視する機能を追加しました。
	- 認証解除時に資格情報とクッキーを削除する専用の関数を導入しました。

- **リファクタリング**
	- HTTPクライアントの初期化と終了時のクッキーの取り扱いを条件付きで実行するように変更しました。

- **バグ修正**
	- 特定のコマンドパスでクッキーのロードとセーブを適切に制御することで、ユーザーの操作がより安全になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->