### PR TITLE
タイトル前後の空白を除去するようにした

### DIFF
--- a/crawler/contest.go
+++ b/crawler/contest.go
@@ -67,7 +67,7 @@ func (c *Contest) Do(ctx context.Context, req *requests.Contest) (*responses.Con
 
 func (c *Contest) parseTitle(ctx context.Context, doc *goquery.Document) (string, error) {
 	// <nav><ul class="nav"><li><a class="contest-title" href="/contests/abc342">AtCoder Beginner Contest 342</a></li></ul></nav>
-	title := doc.FindMatcher(goquery.Single("nav ul.nav li a.contest-title")).Text()
+	title := strings.TrimSpace(doc.FindMatcher(goquery.Single("nav ul.nav li a.contest-title")).Text())
 	logs.FromContext(ctx).With("text", title).Debug("find result")
 	if title == "" {
 		return "", errors.New("no title is found")

--- a/crawler/contest_task.go
+++ b/crawler/contest_task.go
@@ -86,7 +86,7 @@ func (c *ContestTask) parseTask(ctx context.Context, tr *goquery.Selection) (*re
 		logger.Error("symbol must not be empty")
 		return nil, errors.New("failed to find symbol")
 	}
-	title := tds.Eq(1).Text()
+	title := strings.TrimSpace(tds.Eq(1).Text())
 	if len(title) == 0 {
 		logger.Error("title must not be empty")
 		return nil, errors.New("failed to find title")


### PR DESCRIPTION
HTMLの解析時にタイトルの前後に含まれることがある空白を除去するようにしました  
対象はコンテストのタイトルと問題のタイトルです

- `atgo contest abc301` を実行後のDB

```
sqlite> select * from tasks;
abc301_a|Overall Winner|2000000000|1073741824||0
abc301_b|Fill the Gaps|2000000000|1073741824||0
abc301_c|AtCoder Cards|2000000000|1073741824||0
abc301_d|Bitmask|2000000000|1073741824||0
abc301_e|Pac-Takahashi|5000000000|1073741824||0
abc301_f|Anti-DDoS|2000000000|1073741824||0
abc301_g|Worst Picture|4000000000|1073741824||0
abc301_h|Difference of Distance|5000000000|1073741824||0
```

#37 に報告の状態と比べてタイトルの前後空白がなくなっていることを確認済

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
	- コンテストのタイトルが正確に取得されるように、タイトルの前後の空白を削除する処理を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->