### PR TITLE
Go1.20環境下で利用できるようgo.modのテンプレート記述を調整

### DIFF
--- a/tmpl/templates/task/go_mod.tmpl
+++ b/tmpl/templates/task/go_mod.tmpl
@@ -1,6 +1,6 @@
 module atcoder
 
-go 1.20.6
+go 1.20
 
 require github.com/stretchr/testify v1.9.0
 


### PR DESCRIPTION
Go1.20ではgo moduleのgo directiveを[major].[minor]で指定する必要があるため、それに合わせてテンプレートを修正しました