### PR TITLE
入出力サンプルが取得できない不具合を修正

### DIFF
--- a/crawler/task.go
+++ b/crawler/task.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -99,11 +98,9 @@ func (c *TaskCrawler) parseSamples(ctx context.Context, doc *goquery.Document) (
 		return nil, err
 	}
 
-	cp := regexp.MustCompile(`^\s*入力例\s*\d+$`)
-
 	// Sample Input の数 = sampleの数
 	count := doc.Find("h3").FilterFunction(func(i int, s *goquery.Selection) bool {
-		return cp.MatchString(s.Text())
+		return strings.HasPrefix(s.Text(), "入力例")
 	}).Length()
 	logger := logs.FromContext(ctx).With("sample count", count)
 


### PR DESCRIPTION
入力値のヘッダにスペースが含まれないケースでサンプルの入出力が取得できないケースがあったので取得できるように修正しました。

### 変更前

- サンプルの数は `入力例 ` の文字列で始まるh3をカウント
- サンプルの判別は `入力例 %d` と `出力例 %d` で検査していた

### 変更後

- サンプルの数は `^\s*入力例\s*\d+$` に一致するh3をカウント
    - 今まで前方にスペースはなかったが念の為前方にスペースが含まれるタイトルも許容した
    - `入力例 1` でも `入力例1` でも引っ掛けられるようにした
- サンプルの判別はh3のテキストから **スペースを除いて** `入力例%d` と `出力例%d` で検査するようにした
    - スペースが入るかどうかは重要ではないので潰した上で判別する


closes #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **バグ修正**
  - 入力サンプルセクションを特定するための正規表現パターンを導入し、HTMLコンテンツ内の入力および出力例の検出ロジックを調整しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->