### PR TITLE
Silicon Mac(M2)でアーキテクチャが認識しない不具合を修正

### DIFF
--- a/install
+++ b/install
@@ -18,6 +18,7 @@ goarch() {
     case $(uname -m) in
         x86_64)  echo amd64 ;;
         aarch64) echo arm64 ;;
+        arm64) echo arm64 ;;
         *)       echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
     esac
 }


### PR DESCRIPTION
M2 Mac上でインストールを行うと

```
$ curl -sSfL https://raw.githubusercontent.com/meian/atgo/main/install | bash
Unsupported architecture: arm64
Not found prebuilt binary for darwin/v0.0.4 in 
```

アーキテクチャがサポート外というエラーが返った。

Silicon系のMac上では `arm64` が返るようなので処理対象として追加する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - `install`スクリプトにおいて、`arm64`アーキテクチャのサポートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->