### PR TITLE
atgo contest でコンテストIDが指定されない場合に前回参照したコンテストIDを利用するよう変更した

### DIFF
--- a/cmd/contest.go
+++ b/cmd/contest.go
@@ -18,12 +18,13 @@ var contestCmd = &cobra.Command{
 	Short: "Display contest info",
 	Long:  `Display contest and associated tasks.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) == 0 {
-			return errors.New("contest ID is required")
+		ctx := cmd.Context()
+		var contestID string
+		if len(args) > 0 {
+			contestID = args[0]
 		}
-		contestID := args[0]
-		logger := logs.FromContext(cmd.Context()).With("contestID", contestID)
-		ctx := logs.ContextWith(cmd.Context(), logger)
+		logger := logs.FromContext(ctx).With("contestID", contestID)
+		ctx = logs.ContextWith(ctx, logger)
 
 		p := usecase.ContestParam{
 			ContestID: contestID,

--- a/crawler/login.go
+++ b/crawler/login.go
@@ -47,7 +47,7 @@ func (c *Login) Do(ctx context.Context, req *requests.Login) (*responses.Login, 
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != gohttp.StatusOK {
-		logger.With("status_code", resp.StatusCode).Error("unexpected status code")
+		logger.With("statusCode", resp.StatusCode).Error("unexpected status code")
 		return nil, errors.New("unexpected status code for login")
 	}
 	doc, err := c.crawler.documentFromReader(ctx, resp.Body)

--- a/crawler/submit.go
+++ b/crawler/submit.go
@@ -29,7 +29,7 @@ func (c *Submit) Do(ctx context.Context, req *requests.Submit) (*responses.Submi
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		logger.With("status_code", resp.StatusCode).Error("unexpected status code")
+		logger.With("statusCode", resp.StatusCode).Error("unexpected status code")
 		return nil, errors.New("unexpected status code for submit")
 	}
 	// TODO: URLが違う場合にログを出す

--- a/usecase/common/resolve_task_info.go
+++ b/usecase/common/resolve_task_info.go
@@ -1,0 +1,71 @@
+package common
+
+import (
+	"context"
+	"errors"
+
+	"github.com/meian/atgo/io"
+	"github.com/meian/atgo/logs"
+	"github.com/meian/atgo/models"
+	"github.com/meian/atgo/workspace"
+)
+
+func ResolveTaskInfo(ctx context.Context, contestID, taskID string) (*models.TaskInfo, bool, error) {
+	logger := logs.FromContext(ctx)
+	if len(taskID) > 0 {
+		logger = logger.With("taskID", taskID)
+		if len(contestID) == 0 {
+			cID, err := models.DetectContestID(taskID)
+			if err != nil {
+				logger.Error(err.Error())
+				return nil, false, errors.New("failed to detect contest ID from task ID")
+			}
+			contestID = cID
+		}
+	}
+
+	mustSave := false
+
+	file, ok := workspace.TaskInfoFile()
+	logger = logger.With("info file", file)
+	if !ok {
+		if len(contestID) == 0 {
+			logger.Error("failed to find task info file")
+			return nil, false, errors.New("failed to find task info file")
+		}
+		mustSave = true
+	}
+	if !io.FileExists(file) {
+		if len(contestID) == 0 {
+			logger.Error("failed to find task info file")
+			return nil, false, errors.New("failed to find task info file")
+		}
+		return &models.TaskInfo{
+			ContestID: contestID,
+			TaskID:    taskID,
+		}, true, nil
+	}
+	var info models.TaskInfo
+	if err := info.ReadFile(file); err != nil {
+		logger.Error(err.Error())
+		return nil, false, errors.New("failed to read task info file")
+	}
+	if len(info.ContestID) == 0 {
+		return nil, false, errors.New("cannot get contest ID from task info file")
+	}
+	if len(contestID) > 0 {
+		if info.ContestID != contestID {
+			info.ContestID = contestID
+			info.TaskID = taskID
+			mustSave = true
+		}
+	}
+	if len(taskID) > 0 {
+		if info.TaskID != taskID {
+			info.TaskID = taskID
+			mustSave = true
+		}
+	}
+
+	return &info, mustSave, nil
+}

--- a/usecase/task.go
+++ b/usecase/task.go
@@ -11,6 +11,7 @@ import (
 	"github.com/meian/atgo/logs"
 	"github.com/meian/atgo/models"
 	"github.com/meian/atgo/repo"
+	"github.com/meian/atgo/usecase/common"
 	"github.com/meian/atgo/workspace"
 	"github.com/pkg/errors"
 	"gopkg.in/guregu/null.v3"
@@ -31,18 +32,17 @@ type TaskResult struct {
 }
 
 func (u Task) Run(ctx context.Context, param TaskParam) (*TaskResult, error) {
-	logger := logs.FromContext(ctx)
+	info, mustSave, err := u.resolveTaskInfo(ctx, param)
+	if err != nil {
+		return nil, err
+	}
+	logger := logs.FromContext(ctx).With("contestID", info.ContestID).With("taskID", info.TaskID)
+	ctx = logs.ContextWith(ctx, logger)
+
 	dbConn := database.NewDBConn(database.FromContext(ctx))
 	crepo := repo.NewContestWithDBConn(dbConn)
 	ctrepo := repo.NewContestTaskWithDBConn(dbConn)
 	trepo := repo.NewTaskWithDBConn(dbConn)
-
-	info, err := u.resolveTaskInfo(ctx, param)
-	if err != nil {
-		return nil, err
-	}
-	logger = logger.With("contestID", info.ContestID).With("taskID", info.TaskID)
-	ctx = logs.ContextWith(ctx, logger)
 
 	task, err := trepo.Find(ctx, info.TaskID)
 	if err != nil {
@@ -81,7 +81,7 @@ func (u Task) Run(ctx context.Context, param TaskParam) (*TaskResult, error) {
 		return nil, errors.New("failed to find contest task")
 	}
 	if ct == nil {
-		return nil, errors.New("not related contest and task")
+		return nil, errors.New("the specified contest and task are not related")
 	}
 	if param.ShowSamples {
 		task, err = trepo.FindWithSamples(ctx, info.TaskID)
@@ -93,10 +93,12 @@ func (u Task) Run(ctx context.Context, param TaskParam) (*TaskResult, error) {
 		return nil, errors.New("failed to find task with samples")
 	}
 
-	taskFile, _ := workspace.TaskInfoFile()
-	if err := info.WriteFile(taskFile); err != nil {
-		logger.Error(err.Error())
-		return nil, errors.New("failed to write task info file")
+	if mustSave {
+		taskFile, _ := workspace.TaskInfoFile()
+		if err := info.WriteFile(taskFile); err != nil {
+			logger.Error(err.Error())
+			return nil, errors.New("failed to write task info file")
+		}
 	}
 
 	return &TaskResult{
@@ -107,51 +109,20 @@ func (u Task) Run(ctx context.Context, param TaskParam) (*TaskResult, error) {
 
 }
 
-func (u Task) resolveTaskInfo(ctx context.Context, param TaskParam) (*models.TaskInfo, error) {
-	logger := logs.FromContext(ctx)
-	if len(param.TaskID) > 0 {
-		logger = logger.With("taskID", param.TaskID)
-		if len(param.ContestID) == 0 {
-			contestID, err := models.DetectContestID(param.TaskID)
-			if err != nil {
-				logger.Error(err.Error())
-				return nil, errors.New("failed to detect contest ID from task ID")
-			}
-			param.ContestID = contestID
-		}
-		return &models.TaskInfo{
-			TaskID:    param.TaskID,
-			ContestID: param.ContestID,
-		}, nil
+func (u Task) resolveTaskInfo(ctx context.Context, param TaskParam) (*models.TaskInfo, bool, error) {
+	if len(param.TaskID) == 0 && len(param.ContestID) > 0 {
+		return nil, false, errors.New("task ID is required when contest ID is specified")
 	}
-
-	info, err := u.readTaskInfo(ctx)
+	logger := logs.FromContext(ctx).With("contestID", param.ContestID).With("taskID", param.TaskID)
+	info, mustSave, err := common.ResolveTaskInfo(ctx, param.ContestID, param.TaskID)
 	if err != nil {
-		return nil, err
+		logger.Error(err.Error())
+		return nil, false, errors.New("task ID cannot be determined")
 	}
 	if len(info.TaskID) == 0 {
-		return nil, errors.New("not set task ID in task info file")
+		return nil, false, errors.New("task ID cannot be determined")
 	}
-	if len(info.ContestID) == 0 {
-		return nil, errors.New("not set contest ID in task info file")
-	}
-	return info, nil
-}
-
-func (u Task) readTaskInfo(ctx context.Context) (*models.TaskInfo, error) {
-	logger := logs.FromContext(ctx)
-	file, ok := workspace.TaskInfoFile()
-	logger = logger.With("info file", file)
-	if !ok {
-		logger.Error("not found task info file")
-		return nil, errors.New("not found task info file")
-	}
-	var info models.TaskInfo
-	if err := info.ReadFile(file); err != nil {
-		logger.Error(err.Error())
-		return nil, errors.New("failed to read task info file")
-	}
-	return &info, nil
+	return info, mustSave, nil
 }
 
 func (u Task) createTask(ctx context.Context, contestID string, taskID string) (*models.Task, error) {

--- a/usecase/task.go
+++ b/usecase/task.go
@@ -81,7 +81,7 @@ func (u Task) Run(ctx context.Context, param TaskParam) (*TaskResult, error) {
 		return nil, errors.New("failed to find contest task")
 	}
 	if ct == nil {
-		return nil, errors.New("not related contest anc task")
+		return nil, errors.New("not related contest and task")
 	}
 	if param.ShowSamples {
 		task, err = trepo.FindWithSamples(ctx, info.TaskID)


### PR DESCRIPTION
- 最後に `atgo contest` または `atgo task` した時のコンテストIDを保存するようにした
    - `atgo contest` をID指定で呼び出した場合はタスクIDが記録されないので、影響として `atgo task` を引数なしで呼び出す際に、以前に `atgo contest` をID指定で呼び出して `atgo task` を呼び出していない場合はエラーになるようになった
- `atgo contest` に対してコンテストIDを必須じゃなくし、未指定時は前回に `atgo contest` や `atgo task` した際のコンテスト情報を表示できるようにした


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - コンテスト情報を解決する新しい機能を導入しました。これにより、コンテストIDに基づいてタスク情報の取得と更新が可能になりました。

- **バグ修正**
  - コンテストIDの入力処理を改良し、エラーメッセージとエラー処理を改善しました。

- **改善**
  - ロギングとエラーメッセージの改善により、デバッグがしやすくなりました。
  - コンテキストを利用した処理の効率化を行いました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->