### PR TITLE
authパッケージのテストを追加

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -44,7 +44,7 @@ func Read(ctx context.Context, file string) (string, string, error) {
 	return username, password, nil
 }
 
-func Store(ctx context.Context, file, user, password string) error {
+func Write(ctx context.Context, file, user, password string) error {
 	logger := logs.FromContext(ctx).With("file", file)
 	fw, err := os.Create(file)
 	if err != nil {

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -1,0 +1,195 @@
+package auth_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/meian/atgo/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	existDir   string
+	noExistDir string
+)
+
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		panic(err)
+	}
+	existDir = dir
+	defer func() {
+		os.RemoveAll(existDir)
+	}()
+	dir, err = os.MkdirTemp("", "")
+	if err != nil {
+		panic(err)
+	}
+	noExistDir = dir
+	if err := os.RemoveAll(noExistDir); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}
+
+func TestRead(t *testing.T) {
+	type args struct {
+		file string
+	}
+	type want struct {
+		err      bool
+		user     string
+		password string
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "valid1",
+			args: args{
+				file: filepath.Join(testDataDir(), "valid1"),
+			},
+			want: want{
+				user:     "sample-user",
+				password: "sample-password",
+			},
+		},
+		{
+			name: "valid2",
+			args: args{
+				file: filepath.Join(testDataDir(), "valid2"),
+			},
+			want: want{
+				user:     "user2",
+				password: "abcdefghijklmn",
+			},
+		},
+		{
+			name: "file not found",
+			args: args{
+				file: filepath.Join(testDataDir(), "not found"),
+			},
+			want: want{
+				err: true,
+			},
+		},
+		{
+			name: "illegal base64",
+			args: args{
+				file: filepath.Join(testDataDir(), "illegal-base64"),
+			},
+			want: want{
+				err: true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			user, password, err := auth.Read(context.Background(), tt.args.file)
+			t.Logf("user: %s", user)
+			t.Logf("password: %s", password)
+			if tt.want.err {
+				assert.Error(err)
+				return
+			}
+
+			assert.NoError(err)
+			assert.Equal(tt.want.user, user)
+			assert.Equal(tt.want.password, password)
+		})
+	}
+}
+
+func TestWrite(t *testing.T) {
+	type args struct {
+		file     string
+		user     string
+		password string
+	}
+	type want struct {
+		err      bool
+		testdata string
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "valid1",
+			args: args{
+				file:     filepath.Join(existDir, "valid1"),
+				user:     "sample-user",
+				password: "sample-password",
+			},
+			want: want{
+				testdata: "valid1",
+			},
+		},
+		{
+			name: "valid2",
+			args: args{
+				file:     filepath.Join(existDir, "valid2"),
+				user:     "user2",
+				password: "abcdefghijklmn",
+			},
+			want: want{
+				testdata: "valid2",
+			},
+		},
+		{
+			name: "no parent directory",
+			args: args{
+				file:     filepath.Join(noExistDir, "credential"),
+				user:     "user",
+				password: "password",
+			},
+			want: want{
+				err: true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			err := auth.Write(context.Background(), tt.args.file, tt.args.user, tt.args.password)
+			if tt.want.err {
+				assert.Error(err)
+				return
+			}
+
+			if !assert.NoError(err) {
+				return
+			}
+			if !assert.FileExists(tt.args.file) {
+				return
+			}
+			cf, err := os.ReadFile(tt.args.file)
+			require.NoError(err)
+
+			wantfile := filepath.Join(testDataDir(), tt.want.testdata)
+			require.FileExists(wantfile)
+			testdata, err := os.ReadFile(wantfile)
+			require.NoError(err)
+
+			assert.Equal(string(testdata), string(cf))
+		})
+	}
+}
+
+func testDataDir() string {
+	_, b, _, _ := runtime.Caller(0)
+	bp := filepath.Dir(b)
+	return filepath.Join(bp, "testdata", "credentials")
+}

--- a/auth/testdata/credentials/illegal-base64
+++ b/auth/testdata/credentials/illegal-base64
@@ -1,0 +1,2 @@
+sample-user
+kwytbbefvhiema2ik3bxabc

--- a/auth/testdata/credentials/valid1
+++ b/auth/testdata/credentials/valid1
@@ -1,0 +1,2 @@
+sample-user
+kwYtbBEfVHIEMa2iK3BX

--- a/auth/testdata/credentials/valid2
+++ b/auth/testdata/credentials/valid2
@@ -1,0 +1,2 @@
+user2
+gQUjeBgcHmoMKLW5KWw=

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -56,7 +56,7 @@ var authCmd = &cobra.Command{
 			return err
 		}
 		file := workspace.CredentialFile()
-		if err := auth.Store(ctx, file, user, password); err != nil {
+		if err := auth.Write(ctx, file, user, password); err != nil {
 			return err
 		}
 		cmd.Printf("Credential is stored: %s\n", file)

--- a/cmd/authSample.go
+++ b/cmd/authSample.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/meian/atgo/auth"
+	"github.com/spf13/cobra"
+)
+
+var authSampleFlag struct {
+	user     string
+	password string
+}
+
+// authSampleCmd represents the authSample command
+var authSampleCmd = &cobra.Command{
+	Use:    "auth-sample",
+	Short:  "For development",
+	Long:   `Write sample credential file`,
+	Hidden: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		tmp, err := os.CreateTemp("", "")
+		if err != nil {
+			return err
+		}
+		if err := tmp.Close(); err != nil {
+			return err
+		}
+		file := tmp.Name()
+		defer os.Remove(file)
+		if err := auth.Write(cmd.Context(), file, authSampleFlag.user, authSampleFlag.password); err != nil {
+			return err
+		}
+		c, err := os.ReadFile(file)
+		if err != nil {
+			return err
+		}
+		_, err = cmd.OutOrStdout().Write(c)
+		return err
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(authSampleCmd)
+	authSampleCmd.Flags().StringVar(&authSampleFlag.user, "user", "sample-user", "User name")
+	authSampleCmd.Flags().StringVar(&authSampleFlag.password, "password", "sample-password", "Password")
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
+	github.com/stretchr/testify v1.9.0
 	gopkg.in/guregu/null.v3 v3.5.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/gorm v1.25.11
@@ -20,6 +21,7 @@ require (
 require (
 	github.com/andybalholm/cascadia v1.3.2 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/glebarez/go-sqlite v1.21.2 // indirect
@@ -35,6 +37,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect


### PR DESCRIPTION
authパッケージ配下にテストを追加しました。

- Read / Writeのテスト
    - Store => Writeの方がReadと対比できる命名なので変更した
- テストデータを作成するための隠しコマンドを追加
    - 削除はしないがオートコンプリートには引っかからないはず

CIでのテスト実行は別のPRで追加します

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ユーザー認証に関連する新しいテストファイルを追加しました。
  - CLIコマンド「auth-sample」を導入し、サンプルユーザー認証情報を簡単に作成できるようにしました。

- **バグ修正**
  - 認証情報の保存方法を明確にするため、ストレージ関数の名称を「Store」から「Write」に変更しました。

- **ドキュメント**
  - テスト用のユーザー認証情報ファイルを追加し、無効なデータに対する処理を確認できるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->