### PR TITLE
認証ファイル周りのロジックを簡素化

### DIFF
--- a/auth/aes.go
+++ b/auth/aes.go
@@ -9,20 +9,17 @@ import (
 )
 
 var (
-	key = "fedcba9876543210"
-	iv  = []byte(key)
+	key = []byte("fedcba9876543210")
+	iv  = key
 )
 
-func encrypt(data string) (string, error) {
+func encrypt(data string) string {
 	d := []byte(data)
-	block, err := aes.NewCipher([]byte(key))
-	if err != nil {
-		return "", errors.Wrap(err, "failed to create new cipher")
-	}
+	block, _ := aes.NewCipher(key)
 	cipherText := make([]byte, len(d))
 	cfb := cipher.NewCFBEncrypter(block, iv)
 	cfb.XORKeyStream(cipherText, d)
-	return base64.StdEncoding.EncodeToString(cipherText), nil
+	return base64.StdEncoding.EncodeToString(cipherText)
 }
 
 func decrypt(encryptedBase64 string) (string, error) {
@@ -30,10 +27,7 @@ func decrypt(encryptedBase64 string) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "failed to decode base64")
 	}
-	block, err := aes.NewCipher([]byte(key))
-	if err != nil {
-		return "", errors.Wrap(err, "failed to create new cipher")
-	}
+	block, _ := aes.NewCipher(key)
 	plainText := make([]byte, len(cipherText))
 	cfb := cipher.NewCFBDecrypter(block, iv)
 	cfb.XORKeyStream(plainText, cipherText)


### PR DESCRIPTION
認証情報ファイルの取り回しを簡素化しました

- cipherの生成は固定の成功するバイナリに対して行われるのでエラーを無視するようにした
    - その結果、 `encrypt` はエラーを返す必要がなくなった
- `Write` の書き込みでfmt.FPrintlnを使うように変更した
    - そこまでパフォーマンスを気にする処理ではないため
- `Read` は一度全て読み出してから改行で区切って解析するようにした


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- AES暗号化および復号化機能のインターフェースを簡素化しました。
	- ユーザー資格情報の読み取りと書き込み機能を改善し、エラー処理を強化しました。

- **バグ修正**
	- ファイルの読み取りと書き込みの処理を見直し、エラーの可能性を低減しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->