### PR TITLE
未使用の CSRFToken を削除

### DIFF
--- a/crawler/login.go
+++ b/crawler/login.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/meian/atgo/crawler/requests"
 	"github.com/meian/atgo/crawler/responses"
-	"github.com/meian/atgo/csrf"
 	"github.com/meian/atgo/http"
 	"github.com/meian/atgo/logs"
 	"github.com/meian/atgo/url"
@@ -53,7 +52,6 @@ func (c *Login) Do(ctx context.Context, req *requests.Login) (*responses.Login, 
 		return nil, err
 	}
 	return &responses.Login{
-		LoggedIn:  c.crawler.LoggedIn(ctx, doc),
-		CSRFToken: csrf.FromCookies(ctx, resp.Cookies()),
+		LoggedIn: c.crawler.LoggedIn(ctx, doc),
 	}, nil
 }

--- a/crawler/responses/login.go
+++ b/crawler/responses/login.go
@@ -1,6 +1,5 @@
 package responses
 
 type Login struct {
-	LoggedIn  bool
-	CSRFToken string
+	LoggedIn bool
 }


### PR DESCRIPTION
`CSRFToken` という未使用だったresponses.Loginのフィールドとその周辺の処理を削除しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ログインプロセスからCSRFトークンの処理を削除し、レスポンス構造を簡素化しました。

- **バグ修正**
  - CSRFトークンに関連する依存関係を削減し、ログインのパフォーマンスを向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->