### PR TITLE
csrfパッケージのテストを追加

### DIFF
--- a/csrf/cookie.go
+++ b/csrf/cookie.go
@@ -28,9 +28,11 @@ func fromCookie(ctx context.Context, cookie *http.Cookie) string {
 	}
 	v := cookie.Value[tokenPos+len(header):]
 	endPos := strings.Index(v, "%00")
-	if endPos > 0 {
-		v = v[:endPos]
+	if endPos < 0 {
+		logger.Error("csrf token is not terminate with %00")
+		return ""
 	}
+	v = v[:endPos]
 	v, err := url.QueryUnescape(v)
 	if err != nil {
 		logger.Error(err.Error())

--- a/csrf/cookie_test.go
+++ b/csrf/cookie_test.go
@@ -1,0 +1,56 @@
+package csrf_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/meian/atgo/csrf"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFromCookies(t *testing.T) {
+
+	dummy := &http.Cookie{Name: "dummy", Value: "TS%3A1737311369%00%00csrf_token%3Adummy_csrf_token%00"}
+	rSession := &http.Cookie{Name: "REVEL_SESSION", Value: "TS%3A1737311369%00%00csrf_token%3Atest_csrf_token%00"}
+	noCSRF := &http.Cookie{Name: "REVEL_SESSION", Value: "TS%3A1737311369%00"}
+	noTerminate := &http.Cookie{Name: "REVEL_SESSION", Value: "TS%3A1737311369%00%00csrf_token%3Atest_csrf_token"}
+	invalidToken := &http.Cookie{Name: "REVEL_SESSION", Value: "TS%3A1737311369%00%00csrf_token%3A%test_csrf_token%00"}
+
+	tests := []struct {
+		name    string
+		cookies []*http.Cookie
+		want    string
+	}{
+		{
+			name:    "valid",
+			cookies: []*http.Cookie{dummy, rSession},
+			want:    "test_csrf_token",
+		},
+		{
+			name:    "no REVEL_SESSION",
+			cookies: []*http.Cookie{dummy},
+			want:    "",
+		},
+		{
+			name:    "no csrf_token",
+			cookies: []*http.Cookie{dummy, noCSRF},
+			want:    "",
+		},
+		{
+			name:    "no terminate",
+			cookies: []*http.Cookie{dummy, noTerminate},
+			want:    "",
+		},
+		{
+			name:    "invalid token",
+			cookies: []*http.Cookie{dummy, invalidToken},
+			want:    "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, csrf.FromCookies(context.Background(), tt.cookies))
+		})
+	}
+}

--- a/csrf/document_test.go
+++ b/csrf/document_test.go
@@ -1,0 +1,52 @@
+package csrf_test
+
+import (
+	"embed"
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/meian/atgo/csrf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	//go:embed testdata/document
+	testdata embed.FS
+)
+
+func TestFromDocument(t *testing.T) {
+	htmlm := testHTMLMap(t)
+
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: "valid", want: "test_csrf_token"},
+		{name: "no-head", want: ""},
+		{name: "no-script", want: ""},
+		{name: "no-token", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc, err := goquery.NewDocumentFromReader(strings.NewReader(htmlm[tt.name+".html"]))
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, csrf.FromDocument(doc))
+		})
+	}
+}
+
+func testHTMLMap(t *testing.T) map[string]string {
+	t.Helper()
+	m := make(map[string]string)
+	es, err := testdata.ReadDir("testdata/document")
+	require.NoError(t, err)
+	for _, e := range es {
+		require.False(t, e.IsDir())
+		b, err := testdata.ReadFile("testdata/document/" + e.Name())
+		require.NoError(t, err)
+		m[e.Name()] = string(b)
+	}
+	return m
+}

--- a/csrf/testdata/document/no-head.html
+++ b/csrf/testdata/document/no-head.html
@@ -1,0 +1,6 @@
+<html>
+    <body>
+        <h1>Without head tag.</h1>
+        <p>This is a document without head tag.</p>
+    </body>
+</html>

--- a/csrf/testdata/document/no-script.html
+++ b/csrf/testdata/document/no-script.html
@@ -1,0 +1,9 @@
+<html>
+    <head>
+        <title>No Script Tag</title>
+    </head>
+    <body>
+        <h1>No Script Tag</h1>
+        <p>This is a document without script tag.</p>
+    </body>
+</html>

--- a/csrf/testdata/document/no-token.html
+++ b/csrf/testdata/document/no-token.html
@@ -1,0 +1,11 @@
+<html>
+    <head>
+        <title>No CSRF Token</title>
+        <script>// no affected</script>
+        <script>// no affected</script>
+    </head>
+    <body>
+        <h1>No CSRF Token</h1>
+        <p>This is a document without CSRF token.</p>
+    </body>
+</html>

--- a/csrf/testdata/document/valid.html
+++ b/csrf/testdata/document/valid.html
@@ -1,0 +1,13 @@
+<html>
+    <head>
+        <title>Valid Document</title>
+        <script>// no affected</script>
+        <script>
+            var csrfToken = "test_csrf_token";
+        </script>
+    </head>
+    <body>
+        <h1>Valid Document</h1>
+        <p>This is a valid document.</p>
+    </body>
+</html>


### PR DESCRIPTION
以下のテストを追加しました

それぞれの関数の仕様は以下の通りです。

- csrf.FromCookies
    - `[]http.Cookie` 内で `csrf_token%3Atoken_text%00` を含む `name=REVEL_SESSION` のcookieからトークンを取得している
    - 該当のcookieがなかったり解析に失敗した場合は空文字列で返す
- csrf.FromDocument
    - goquery.Document内で `var csrfToken = "token_text"` を含む head > scriptタグからトークンを取得している
    - 解析に失敗した場合は空文字列で返す


@coderabbitai

上記関数仕様に対してテストケースが過不足なく適切であるかレビューをお願いします

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - CSRFトークンの取り扱いが改善され、適切なエラーログが追加されました。
  - 新しいHTMLドキュメントが導入され、CSRFトークンの有無などさまざまなシナリオを示すためのテストデータが作成されました。

- **バグ修正**
  - CSRFトークンの抽出に関するロジックを強化し、無効なトークン形式に対して正しく対応できるようになりました。

- **テスト**
  - CSRFの機能に対する新しい単体テストが作成され、異なる条件下での動作が確認されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->