### PR TITLE
クローラーの構造体名を変更

### DIFF
--- a/crawler/task.go
+++ b/crawler/task.go
@@ -17,15 +17,15 @@ import (
 	"github.com/pkg/errors"
 )
 
-type TaskCrawler struct {
+type Task struct {
 	crawler *Crawler
 }
 
-func NewTaskCrawler(client *http.Client) *TaskCrawler {
-	return &TaskCrawler{crawler: NewCrawler(url.TaskPath).WithClient(client)}
+func NewTask(client *http.Client) *Task {
+	return &Task{crawler: NewCrawler(url.TaskPath).WithClient(client)}
 }
 
-func (c *TaskCrawler) Do(ctx context.Context, req *requests.Task) (*responses.Task, error) {
+func (c *Task) Do(ctx context.Context, req *requests.Task) (*responses.Task, error) {
 	logger := logs.FromContext(ctx).With(
 		slog.Group("request",
 			slog.Any("contestID", req.ContestID),
@@ -64,7 +64,7 @@ func (c *TaskCrawler) Do(ctx context.Context, req *requests.Task) (*responses.Ta
 	}, nil
 }
 
-func (c *TaskCrawler) parseScore(ctx context.Context, doc *goquery.Document) (*int, error) {
+func (c *Task) parseScore(ctx context.Context, doc *goquery.Document) (*int, error) {
 
 	stmt, err := c.taskStatement(ctx, doc)
 	if err != nil {
@@ -91,7 +91,7 @@ func (c *TaskCrawler) parseScore(ctx context.Context, doc *goquery.Document) (*i
 	return &score, nil
 }
 
-func (c *TaskCrawler) parseSamples(ctx context.Context, doc *goquery.Document) ([]responses.Task_Sample, error) {
+func (c *Task) parseSamples(ctx context.Context, doc *goquery.Document) ([]responses.Task_Sample, error) {
 
 	stmt, err := c.taskStatement(ctx, doc)
 	if err != nil {
@@ -133,7 +133,7 @@ func (c *TaskCrawler) parseSamples(ctx context.Context, doc *goquery.Document) (
 	return samples, nil
 }
 
-func (c *TaskCrawler) taskStatement(ctx context.Context, doc *goquery.Document) (*goquery.Selection, error) {
+func (c *Task) taskStatement(ctx context.Context, doc *goquery.Document) (*goquery.Selection, error) {
 	// span.stmt がない場合もあるので、その場合は div.task-statement を対象にする
 	stmt := doc.Find("span.lang-ja")
 	if stmt.Length() == 0 {

--- a/usecase/submit.go
+++ b/usecase/submit.go
@@ -116,7 +116,7 @@ func (u Submit) login(ctx context.Context, info models.TaskInfo) (bool, string, 
 		ContestID: info.ContestID,
 		TaskID:    info.TaskID,
 	}
-	res, err := crawler.NewTaskCrawler(client).Do(ctx, req)
+	res, err := crawler.NewTask(client).Do(ctx, req)
 	if err != nil {
 		logger.Error(err.Error())
 		return false, "", errors.New("failed to get task")
@@ -149,7 +149,7 @@ func (u Submit) login(ctx context.Context, info models.TaskInfo) (bool, string, 
 		logger.Warn("failed to login")
 		return false, "", nil
 	}
-	res, err = crawler.NewTaskCrawler(client).Do(ctx, req)
+	res, err = crawler.NewTask(client).Do(ctx, req)
 	if err != nil {
 		logger.Error(err.Error())
 		return false, "", errors.New("failed to get task")

--- a/usecase/task.go
+++ b/usecase/task.go
@@ -163,7 +163,7 @@ func (u Task) loadTaskSamples(ctx context.Context, contestID string, task *model
 	logger := logs.FromContext(ctx)
 	client := http.ClientFromContext(ctx)
 	req := &requests.Task{TaskID: task.ID, ContestID: contestID}
-	res, err := crawler.NewTaskCrawler(client).Do(ctx, req)
+	res, err := crawler.NewTask(client).Do(ctx, req)
 	if err != nil {
 		logger.Error(err.Error())
 		return errors.New("failed to get task")


### PR DESCRIPTION
他の構造体の名称が `Crawler` のサフィックスがなかったのに対して `TaskCrawler` だけがサフィックスがついていたので、他の構造体に合わせてサフィックスを削除しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- タスク管理の機能を強化し、タスクの処理に関するコードを簡素化しました。

- **バグ修正**
	- エラーハンドリングを統一し、タスク実行中のエラーが適切にログされるよう改善しました。

- **リファクタリング**
	- `TaskCrawler`構造体を`Task`に改名し、関連するメソッドを更新しました。これにより、タスクの管理と処理がより明確になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->