### PR TITLE
クローラーのrequestのテストに呼び出されたかどうかを判別する値を追加

### DIFF
--- a/crawler/common_test.go
+++ b/crawler/common_test.go
@@ -49,9 +49,10 @@ func testHTMLMap(t *testing.T, target string) htmlMap {
 }
 
 type requestWant struct {
-	path  string
-	query url.Values
-	body  url.Values
+	path   string
+	query  url.Values
+	body   url.Values
+	called bool
 }
 
 type mockRequestRoundTripper struct {
@@ -66,9 +67,12 @@ func (m *mockRequestRoundTripper) RoundTrip(req *http.Request) (*http.Response, 
 	}, nil
 }
 
-type captureFunc func() (method, path string, query, body url.Values)
+type captureFunc func() (method, path string, query, body url.Values, called bool)
 
-func (m *mockRequestRoundTripper) lastCaputure() (string, string, url.Values, url.Values) {
+func (m *mockRequestRoundTripper) lastCaputure() (string, string, url.Values, url.Values, bool) {
+	if m.request == nil {
+		return "", "", nil, nil, false
+	}
 	query := m.request.URL.Query()
 	body := url.Values{}
 	if m.request.Body != nil {
@@ -79,7 +83,7 @@ func (m *mockRequestRoundTripper) lastCaputure() (string, string, url.Values, ur
 			panic(errors.Wrapf(err, "cannot parse request body: %s", string(b)))
 		}
 	}
-	return m.request.Method, m.request.URL.Path, query, body
+	return m.request.Method, m.request.URL.Path, query, body, true
 }
 
 func mockRequestClient() (*http.Client, captureFunc) {

--- a/crawler/contest_task_test.go
+++ b/crawler/contest_task_test.go
@@ -14,23 +14,42 @@ import (
 )
 
 func TestContestTask_Do_Request(t *testing.T) {
-	req := &requests.ContestTask{
-		ContestID: "abc123",
-	}
-	want := requestWant{
-		path:  "/contests/abc123/tasks",
-		query: url.Values{},
-		body:  url.Values{},
+	tests := []struct {
+		name string
+		req  *requests.ContestTask
+		want requestWant
+	}{
+		{
+			name: "success",
+			req: &requests.ContestTask{
+				ContestID: "abc123",
+			},
+			want: requestWant{
+				path:   "/contests/abc123/tasks",
+				query:  url.Values{},
+				body:   url.Values{},
+				called: true,
+			},
+		},
 	}
 
-	assert := assert.New(t)
-	client, cFunc := mockRequestClient()
-	_, _ = crawler.NewContestTask(client).Do(context.Background(), req)
-	method, path, query, body := cFunc()
-	assert.Equal(http.MethodGet, method)
-	assert.Equal(want.path, path)
-	assert.Equal(want.query, query)
-	assert.Equal(want.body, body)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			client, cFunc := mockRequestClient()
+			_, _ = crawler.NewContestTask(client).Do(context.Background(), tt.req)
+			method, path, query, body, called := cFunc()
+			if !tt.want.called {
+				assert.False(called)
+				return
+			}
+			assert.Equal(http.MethodGet, method)
+			assert.Equal(tt.want.path, path)
+			assert.Equal(tt.want.query, query)
+			assert.Equal(tt.want.body, body)
+			assert.True(called)
+		})
+	}
 }
 
 func TestContestTask_Do_Response(t *testing.T) {

--- a/crawler/contest_test.go
+++ b/crawler/contest_test.go
@@ -15,23 +15,43 @@ import (
 )
 
 func TestContest_Do_Request(t *testing.T) {
-	req := &requests.Contest{
-		ContestID: "abc123",
-	}
-	want := requestWant{
-		path:  "/contests/abc123",
-		query: url.Values{},
-		body:  url.Values{},
+
+	tests := []struct {
+		name string
+		req  *requests.Contest
+		want requestWant
+	}{
+		{
+			name: "success",
+			req: &requests.Contest{
+				ContestID: "abc123",
+			},
+			want: requestWant{
+				path:   "/contests/abc123",
+				query:  url.Values{},
+				body:   url.Values{},
+				called: true,
+			},
+		},
 	}
 
-	assert := assert.New(t)
-	client, cFunc := mockRequestClient()
-	_, _ = crawler.NewContest(client).Do(context.Background(), req)
-	method, path, query, body := cFunc()
-	assert.Equal(http.MethodGet, method)
-	assert.Equal(want.path, path)
-	assert.Equal(want.query, query)
-	assert.Equal(want.body, body)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			client, cFunc := mockRequestClient()
+			_, _ = crawler.NewContest(client).Do(context.Background(), tt.req)
+			method, path, query, body, called := cFunc()
+			if !tt.want.called {
+				assert.False(called)
+				return
+			}
+			assert.Equal(http.MethodGet, method)
+			assert.Equal(tt.want.path, path)
+			assert.Equal(tt.want.query, query)
+			assert.Equal(tt.want.body, body)
+			assert.True(called)
+		})
+	}
 }
 
 func TestContest_Do_Response(t *testing.T) {

--- a/crawler/home_test.go
+++ b/crawler/home_test.go
@@ -14,21 +14,40 @@ import (
 )
 
 func TestHome_Do_Request(t *testing.T) {
-	req := &requests.Home{}
-	want := requestWant{
-		path:  "/home",
-		query: url.Values{},
-		body:  url.Values{},
+	tests := []struct {
+		name string
+		req  *requests.Home
+		want requestWant
+	}{
+		{
+			name: "success",
+			req:  &requests.Home{},
+			want: requestWant{
+				path:   "/home",
+				query:  url.Values{},
+				body:   url.Values{},
+				called: true,
+			},
+		},
 	}
 
-	assert := assert.New(t)
-	client, cFunc := mockRequestClient()
-	_, _ = crawler.NewHome(client).Do(context.Background(), req)
-	method, path, query, body := cFunc()
-	assert.Equal(http.MethodGet, method)
-	assert.Equal(want.path, path)
-	assert.Equal(want.query, query)
-	assert.Equal(want.body, body)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			client, cFunc := mockRequestClient()
+			_, _ = crawler.NewHome(client).Do(context.Background(), tt.req)
+			method, path, query, body, called := cFunc()
+			if !tt.want.called {
+				assert.False(called)
+				return
+			}
+			assert.Equal(http.MethodGet, method)
+			assert.Equal(tt.want.path, path)
+			assert.Equal(tt.want.query, query)
+			assert.Equal(tt.want.body, body)
+			assert.True(called)
+		})
+	}
 }
 
 func TestHome_Do_Response(t *testing.T) {


### PR DESCRIPTION
一部パラメータを評価してHTTPの呼び出しを行うかどうかを分岐する箇所が必要になったため、テストのフローで呼び出しが中断されたことを評価できるように呼び出ししたかどうかの値を返せるようにしました

@coderabbitai

既存のテストも合わせて修正しています  
変更点に問題があるかどうか確認をお願いします

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- テストケースをテーブル駆動形式にリファクタリングし、可読性と保守性を向上。
	- 各テストケースに`called`フィールドを追加し、リクエストが呼び出されたかどうかを検証可能に。

- **バグ修正**
	- より明確なアサーションを提供するために、テストの論理フローを改善。

- **ドキュメント**
	- 各テストケース名を付けることで、失敗時のコンテキストを強化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->