### PR TITLE
/contests/archive を呼び出すパラメータの扱いを修正

### DIFF
--- a/crawler/requests/contest_archive.go
+++ b/crawler/requests/contest_archive.go
@@ -34,10 +34,10 @@ func (r ContestArchive) URLValues() url.Values {
 		vals.Add("page", fmt.Sprint(r.Page))
 	}
 	if r.RatedType != nil {
-		vals.Add("ratedType", fmt.Sprintf("%d", r.RatedType))
+		vals.Add("ratedType", fmt.Sprintf("%d", *r.RatedType))
 	}
 	if r.Category != nil {
-		vals.Add("category", fmt.Sprintf("%d", r.Category))
+		vals.Add("category", fmt.Sprintf("%d", *r.Category))
 	}
 	if r.Keyword != nil && len(*r.Keyword) > 0 {
 		vals.Add("keyword", *r.Keyword)

--- a/crawler/requests/contest_archive_test.go
+++ b/crawler/requests/contest_archive_test.go
@@ -1,6 +1,7 @@
 package requests_test
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/meian/atgo/constant"
@@ -94,6 +95,83 @@ func TestContestArchive_Validate(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestContestArchive_URLValues(t *testing.T) {
+	tests := []struct {
+		name string
+		req  requests.ContestArchive
+		want url.Values
+	}{
+		{
+			name: "full params",
+			req: requests.ContestArchive{
+				Page:      1,
+				RatedType: util.ToPtr(constant.RatedTypeAGC),
+				Category:  util.ToPtr(constant.CategoryDailyTraining),
+				Keyword:   util.ToPtr("keyword"),
+			},
+			want: url.Values{
+				"page":      []string{"1"},
+				"ratedType": []string{"3"},
+				"category":  []string{"60"},
+				"keyword":   []string{"keyword"},
+			},
+		},
+		{
+			name: "nil rated type",
+			req: requests.ContestArchive{
+				Page:     1,
+				Category: util.ToPtr(constant.CategoryDailyTraining),
+				Keyword:  util.ToPtr("keyword"),
+			},
+			want: url.Values{
+				"page":     []string{"1"},
+				"category": []string{"60"},
+				"keyword":  []string{"keyword"},
+			},
+		},
+		{
+			name: "nil category",
+			req: requests.ContestArchive{
+				Page:      1,
+				RatedType: util.ToPtr(constant.RatedTypeAGC),
+				Keyword:   util.ToPtr("keyword"),
+			},
+			want: url.Values{
+				"page":      []string{"1"},
+				"ratedType": []string{"3"},
+				"keyword":   []string{"keyword"},
+			},
+		},
+		{
+			name: "nil keyword",
+			req: requests.ContestArchive{
+				Page:      1,
+				RatedType: util.ToPtr(constant.RatedTypeAGC),
+				Category:  util.ToPtr(constant.CategoryDailyTraining),
+			},
+			want: url.Values{
+				"page":      []string{"1"},
+				"ratedType": []string{"3"},
+				"category":  []string{"60"},
+			},
+		},
+		{
+			name: "page only",
+			req: requests.ContestArchive{
+				Page: 1,
+			},
+			want: url.Values{
+				"page": []string{"1"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.req.URLValues())
 		})
 	}
 }


### PR DESCRIPTION
rated-type と category がクエリパラメータとして正しい値が設定されていなかったのを修正しました。  
動作確認のためのテストも合わせて追加しています。

@coderabbitai  
修正内容とテストに問題がないか確認をお願いします

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- `ContestArchive` 構造体の `URLValues` メソッドの改良により、URLパラメータの生成が強化され、nil ポインタのデリファレンスが追加されました。

- **バグ修正**
	- URLパラメータの生成時に発生する可能性のあるnilデリファレンスエラーを防止しました。

- **テスト**
	- `URLValues` メソッドの動作を検証する新しいテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->