### PR TITLE
テーブルモデルのIDに相当するValueObjectの導入

### DIFF
--- a/cmd/contest.go
+++ b/cmd/contest.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/meian/atgo/io"
 	"github.com/meian/atgo/logs"
+	"github.com/meian/atgo/models/ids"
 	"github.com/meian/atgo/text"
 	"github.com/meian/atgo/tmpl"
 	"github.com/meian/atgo/usecase"
@@ -101,7 +102,7 @@ func toContestOutputModel(res *usecase.ContestResult) ContestOutputModel {
 }
 
 type ContestOutputModel struct {
-	ID         string
+	ID         ids.ContestID
 	RatedType  string
 	Title      string
 	StartAt    time.Time
@@ -113,7 +114,7 @@ type ContestOutputModel struct {
 type ContestOutputModel_Task struct {
 	Index        string
 	IndexPadding string
-	ID           string
+	ID           ids.TaskID
 	IDPadding    string
 	Title        string
 	TitlePadding string

--- a/cmd/contestList.go
+++ b/cmd/contestList.go
@@ -84,7 +84,7 @@ func toContestListOutputModel(res *usecase.ContestListResult, ratedType string) 
 		idLen = max(idLen, text.StringWidth(c.ID))
 		titleLen = max(titleLen, text.StringWidth(c.Title))
 		contests = append(contests, ContestListOutputModel_Contest{
-			ID:      c.ID,
+			ID:      string(c.ID),
 			Title:   c.Title,
 			StartAt: c.StartAt,
 			EndAt:   c.StartAt.Add(c.Duration),

--- a/cmd/taskLocalInit.go
+++ b/cmd/taskLocalInit.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/meian/atgo/files"
 	"github.com/meian/atgo/help"
+	"github.com/meian/atgo/models/ids"
 	"github.com/meian/atgo/url"
 	"github.com/meian/atgo/usecase"
 	"github.com/meian/atgo/workspace"
@@ -50,7 +51,7 @@ Do not edit task-local.yaml manually as it is used when submitting code with ` +
 		}
 
 		cmd.Println("local workspace is inited.")
-		cmd.Println(url.TaskURL(res.ContestID, res.TaskID))
+		cmd.Println(url.TaskURL(ids.ContestID(res.ContestID), ids.TaskID(res.TaskID)))
 
 		if !taskLocalInitFlag.noOpen && os.Getenv("TERM_PROGRAM") == "vscode" {
 			ws := workspace.Dir()

--- a/crawler/responses/contest.go
+++ b/crawler/responses/contest.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/meian/atgo/models"
+	"github.com/meian/atgo/models/ids"
 )
 
 type Contest struct {
@@ -16,7 +17,7 @@ type Contest struct {
 
 func (c Contest) ToModel() *models.Contest {
 	return &models.Contest{
-		ID:         c.ID,
+		ID:         ids.ContestID(c.ID),
 		Title:      c.Title,
 		StartAt:    c.StartAt,
 		Duration:   c.Duration,

--- a/crawler/responses/contest_archive.go
+++ b/crawler/responses/contest_archive.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/meian/atgo/models"
+	"github.com/meian/atgo/models/ids"
 	"gopkg.in/guregu/null.v3"
 )
 
@@ -33,7 +34,7 @@ type ContestArchive_Contest struct {
 
 func (c ContestArchive_Contest) ToModel(ratedType *string) models.Contest {
 	return models.Contest{
-		ID:         c.ID,
+		ID:         ids.ContestID(c.ID),
 		RatedType:  null.StringFromPtr(ratedType),
 		Title:      c.Title,
 		StartAt:    c.StartAt,

--- a/crawler/responses/contest_task.go
+++ b/crawler/responses/contest_task.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/meian/atgo/models"
+	"github.com/meian/atgo/models/ids"
 )
 
 type ContestTask struct {
@@ -17,13 +18,13 @@ func (ct ContestTask) ToModel() []models.ContestTask {
 	for i, t := range ct.Tasks {
 		id := fmt.Sprintf("%s-%s", ct.ContestID, t.ID)
 		tasks = append(tasks, models.ContestTask{
-			ID:        id,
-			ContestID: ct.ContestID,
-			TaskID:    t.ID,
+			ID:        ids.ContestTaskID(id),
+			ContestID: ids.ContestID(ct.ContestID),
+			TaskID:    ids.TaskID(t.ID),
 			Order:     i + 1,
 			Index:     t.Index,
 			Task: models.Task{
-				ID:        t.ID,
+				ID:        ids.TaskID(t.ID),
 				Title:     t.Title,
 				TimeLimit: t.TimeLimit,
 				Memory:    t.Memory,

--- a/crawler/submit.go
+++ b/crawler/submit.go
@@ -7,6 +7,7 @@ import (
 	"github.com/meian/atgo/crawler/requests"
 	"github.com/meian/atgo/crawler/responses"
 	"github.com/meian/atgo/logs"
+	"github.com/meian/atgo/models/ids"
 	"github.com/meian/atgo/url"
 	"github.com/pkg/errors"
 )
@@ -34,6 +35,6 @@ func (c *Submit) Do(ctx context.Context, req *requests.Submit) (*responses.Submi
 	}
 	// TODO: URLが違う場合にログを出す
 	return &responses.Submit{
-		Submitted: resp.Request.URL.String() == url.MySubmissionURL(req.ContestID),
+		Submitted: resp.Request.URL.String() == url.MySubmissionURL(ids.ContestID(req.ContestID)),
 	}, nil
 }

--- a/models/contest.go
+++ b/models/contest.go
@@ -3,12 +3,13 @@ package models
 import (
 	"time"
 
+	"github.com/meian/atgo/models/ids"
 	"github.com/meian/atgo/url"
 	"gopkg.in/guregu/null.v3"
 )
 
 type Contest struct {
-	ID         string        `gorm:"primaryKey"`
+	ID         ids.ContestID `gorm:"primaryKey"`
 	RatedType  null.String   `gorm:"index"`
 	Title      string        `gorm:"not null"`
 	StartAt    time.Time     `gorm:"not null"`

--- a/models/contest_task.go
+++ b/models/contest_task.go
@@ -1,13 +1,16 @@
 package models
 
-import "github.com/meian/atgo/url"
+import (
+	"github.com/meian/atgo/models/ids"
+	"github.com/meian/atgo/url"
+)
 
 type ContestTask struct {
-	ID        string `gorm:"primaryKey"`
-	ContestID string `gorm:"not null"`
-	TaskID    string `gorm:"not null"`
-	Order     int    `gorm:"not null"`
-	Index     string `gorm:"not null"`
+	ID        ids.ContestTaskID `gorm:"primaryKey"`
+	ContestID ids.ContestID     `gorm:"not null"`
+	TaskID    ids.TaskID        `gorm:"not null"`
+	Order     int               `gorm:"not null"`
+	Index     string            `gorm:"not null"`
 
 	Task Task `gorm:"constraint:OnDelete:CASCADE"`
 }

--- a/models/detect.go
+++ b/models/detect.go
@@ -3,13 +3,14 @@ package models
 import (
 	"strings"
 
+	"github.com/meian/atgo/models/ids"
 	"github.com/pkg/errors"
 )
 
-func DetectContestID(taskID string) (string, error) {
-	fs := strings.Split(taskID, "_")
+func DetectContestID(taskID ids.TaskID) (ids.ContestID, error) {
+	fs := strings.Split(string(taskID), "_")
 	if len(fs) < 2 {
 		return "", errors.New("cannot detect contest ID from task ID")
 	}
-	return strings.Join(fs[:len(fs)-1], "_"), nil
+	return ids.ContestID(strings.Join(fs[:len(fs)-1], "_")), nil
 }

--- a/models/ids/common.go
+++ b/models/ids/common.go
@@ -1,0 +1,49 @@
+package ids
+
+import "errors"
+
+type modelID interface {
+	~string
+	Validate() error
+}
+
+var (
+	ErrEmptyID = errors.New("empty id")
+)
+
+type errInvalidFormat struct {
+	label string
+	id    string
+}
+
+func (e errInvalidFormat) Error() string {
+	return "invalid " + e.label + " format: " + e.id
+}
+
+func (e errInvalidFormat) String() string {
+	return e.Error()
+}
+
+func newErrInvalidFormat[ID modelID](label string, id ID) error {
+	return errInvalidFormat{label: label, id: string(id)}
+}
+
+type errTooLong struct {
+	label string
+	id    string
+}
+
+func (e errTooLong) Error() string {
+	return e.label + " is too long: " + e.id
+}
+
+func (e errTooLong) String() string {
+	return e.Error()
+}
+
+func validateLen[ID modelID](label string, id ID) error {
+	if len(id) > 64 {
+		return errTooLong{label: label, id: string(id)}
+	}
+	return nil
+}

--- a/models/ids/contest.go
+++ b/models/ids/contest.go
@@ -1,0 +1,24 @@
+package ids
+
+import "regexp"
+
+const contestIDLabel = "contest ID"
+
+var (
+	contestIDPattern = regexp.MustCompile(`^[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*$`)
+)
+
+type ContestID string
+
+func (id ContestID) Validate() error {
+	if id == "" {
+		return ErrEmptyID
+	}
+	if err := validateLen(contestIDLabel, id); err != nil {
+		return err
+	}
+	if !contestIDPattern.MatchString(string(id)) {
+		return newErrInvalidFormat(contestIDLabel, id)
+	}
+	return nil
+}

--- a/models/ids/contest_task.go
+++ b/models/ids/contest_task.go
@@ -1,0 +1,24 @@
+package ids
+
+import "regexp"
+
+const contestTaskIDLabel = "contest task ID"
+
+var (
+	contestTaskIDPattern = regexp.MustCompile(`^[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*--[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*_[a-zA-Z0-9]+$`)
+)
+
+type ContestTaskID string
+
+func (id ContestTaskID) Validate() error {
+	if id == "" {
+		return ErrEmptyID
+	}
+	if err := validateLen(contestTaskIDLabel, id); err != nil {
+		return err
+	}
+	if !contestTaskIDPattern.MatchString(string(id)) {
+		return newErrInvalidFormat(contestTaskIDLabel, id)
+	}
+	return nil
+}

--- a/models/ids/contest_task_test.go
+++ b/models/ids/contest_task_test.go
@@ -1,0 +1,136 @@
+package ids_test
+
+import (
+	"testing"
+
+	"github.com/meian/atgo/models/ids"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContestTaskID_Validate(t *testing.T) {
+	tests := []struct {
+		name     string
+		id       ids.ContestTaskID
+		errMsgPt string
+	}{
+		{
+			name:     "success",
+			id:       "abc123--abc123_a",
+			errMsgPt: "",
+		},
+		{
+			name:     "not contains --",
+			id:       "abc123-abc123_a",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "not contains _",
+			id:       "abc123--abc123a",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "empty",
+			id:       "",
+			errMsgPt: `empty id`,
+		},
+		{
+			name:     "64 chars",
+			id:       "0123456789--ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxy",
+			errMsgPt: "",
+		},
+		{
+			name:     "65 chars",
+			id:       "0123456789--ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz",
+			errMsgPt: `is too long`,
+		},
+		{
+			name:     "first char is -",
+			id:       "-abc123--abc123_a",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "last char is -",
+			id:       "abc123--abc123_a-",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains -",
+			id:       "abc-123--abc123_a",
+			errMsgPt: "",
+		},
+		{
+			name:     "double -",
+			id:       "abc--123--abc123_a",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "first char is _",
+			id:       "_abc123--abc123_a",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "last char is _",
+			id:       "abc123--abc123_a_",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains _",
+			id:       "abc_123--abc123_a",
+			errMsgPt: "",
+		},
+		{
+			name:     "double _",
+			id:       "abc__123--abc123_a",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains double - and _",
+			id:       "abc--123--abc123_a",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains symbol",
+			id:       "abc!123--abc123_a",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains space",
+			id:       "abc 123--abc123_a",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains tab",
+			id:       "abc\t123--abc123_a",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains newline",
+			id:       "abc\n123--abc123_a",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains carriage return",
+			id:       "abc\r123--abc123_a",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "multi byte",
+			id:       "ａｂｃ１２３--ａｂｃ１２３_ａ",
+			errMsgPt: `invalid .+ format:`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			err := tt.id.Validate()
+			if tt.errMsgPt != "" {
+				if !assert.Error(err) {
+					return
+				}
+				assert.Regexp(tt.errMsgPt, err.Error())
+				return
+			}
+			assert.NoError(err)
+		})
+	}
+}

--- a/models/ids/contest_test.go
+++ b/models/ids/contest_test.go
@@ -1,0 +1,131 @@
+package ids_test
+
+import (
+	"testing"
+
+	"github.com/meian/atgo/models/ids"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContestID_Validate(t *testing.T) {
+	tests := []struct {
+		name     string
+		id       ids.ContestID
+		errMsgPt string
+	}{
+		{
+			name:     "success",
+			id:       "abc123",
+			errMsgPt: "",
+		},
+		{
+			name:     "empty",
+			id:       "",
+			errMsgPt: `empty id`,
+		},
+		{
+			name:     "64 chars",
+			id:       "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz01",
+			errMsgPt: "",
+		},
+		{
+			name:     "65 chars",
+			id:       "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz012",
+			errMsgPt: `is too long`,
+		},
+		{
+			name:     "first char is -",
+			id:       "-abc123",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "last char is -",
+			id:       "abc123-",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains -",
+			id:       "abc-123",
+			errMsgPt: "",
+		},
+		{
+			name:     "double -",
+			id:       "abc--123",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "first char is _",
+			id:       "_abc123",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "last char is _",
+			id:       "abc123_",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains _",
+			id:       "abc_123",
+			errMsgPt: "",
+		},
+		{
+			name:     "double _",
+			id:       "abc__123",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains - and _",
+			id:       "abc-1_23",
+			errMsgPt: "",
+		},
+		{
+			name:     "contains double - and _",
+			id:       "abc-_123",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains symbol",
+			id:       "abc!123",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains space",
+			id:       "abc 123",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains tab",
+			id:       "abc\t123",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains carriage return",
+			id:       "abc\r123",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains newline",
+			id:       "abc\n123",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "multi byte",
+			id:       "ａｂｃ１２３",
+			errMsgPt: `invalid .+ format:`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			err := tt.id.Validate()
+			if tt.errMsgPt != "" {
+				if !assert.Error(err) {
+					return
+				}
+				assert.Regexp(tt.errMsgPt, err.Error())
+				return
+			}
+			assert.NoError(err)
+		})
+	}
+}

--- a/models/ids/task.go
+++ b/models/ids/task.go
@@ -1,0 +1,24 @@
+package ids
+
+import "regexp"
+
+const taskIDLabel = "task ID"
+
+var (
+	taskIDPattern = regexp.MustCompile(`^[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*_[a-zA-Z0-9]+$`)
+)
+
+type TaskID string
+
+func (id TaskID) Validate() error {
+	if id == "" {
+		return ErrEmptyID
+	}
+	if err := validateLen(taskIDLabel, id); err != nil {
+		return err
+	}
+	if !taskIDPattern.MatchString(string(id)) {
+		return newErrInvalidFormat(taskIDLabel, id)
+	}
+	return nil
+}

--- a/models/ids/task_sample.go
+++ b/models/ids/task_sample.go
@@ -1,0 +1,24 @@
+package ids
+
+import "regexp"
+
+const taskSampleIDLabel = "task sample ID"
+
+var (
+	taskSampleIDPattern = regexp.MustCompile(`^[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*_[a-zA-Z0-9]+__\d+$`)
+)
+
+type TaskSampleID string
+
+func (id TaskSampleID) Validate() error {
+	if id == "" {
+		return ErrEmptyID
+	}
+	if err := validateLen(taskSampleIDLabel, id); err != nil {
+		return err
+	}
+	if !taskSampleIDPattern.MatchString(string(id)) {
+		return newErrInvalidFormat(taskSampleIDLabel, id)
+	}
+	return nil
+}

--- a/models/ids/task_sample_test.go
+++ b/models/ids/task_sample_test.go
@@ -1,0 +1,141 @@
+package ids_test
+
+import (
+	"testing"
+
+	"github.com/meian/atgo/models/ids"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTaskSampleID_Validate(t *testing.T) {
+	tests := []struct {
+		name     string
+		id       ids.TaskSampleID
+		errMsgPt string
+	}{
+		{
+			name:     "success",
+			id:       "abc123_a__1",
+			errMsgPt: "",
+		},
+		{
+			name:     "not contains _",
+			id:       "abc123a__1",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "not contains __",
+			id:       "abc123_a1",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "_ instead of __",
+			id:       "abc123_a_1",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "empty",
+			id:       "",
+			errMsgPt: `empty id`,
+		},
+		{
+			name:     "64 chars",
+			id:       "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvw_a__1",
+			errMsgPt: "",
+		},
+		{
+			name:     "65 chars",
+			id:       "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwx_a__1",
+			errMsgPt: `is too long`,
+		},
+		{
+			name:     "first char is -",
+			id:       "-abc123_a__1",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "last char is -",
+			id:       "abc123_a__1-",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains -",
+			id:       "abc-123_a__1",
+			errMsgPt: "",
+		},
+		{
+			name:     "double -",
+			id:       "abc--123_a__1",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "first char is _",
+			id:       "_abc123_a__1",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "last char is _",
+			id:       "abc123_a__1_",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains _",
+			id:       "abc_123_a__1",
+			errMsgPt: "",
+		},
+		{
+			name:     "double _",
+			id:       "abc__123_a__1",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains double - and _",
+			id:       "abc-_123_a__1",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains symbol",
+			id:       "abc!123_a__1",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains space",
+			id:       "abc 123_a__1",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains tab",
+			id:       "abc\t123_a__1",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains newline",
+			id:       "abc\n123_a__1",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains carriage return",
+			id:       "abc\r123_a__1",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "multi byte",
+			id:       "ａｂｃ１２３_ａ__１",
+			errMsgPt: `invalid .+ format:`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			err := tt.id.Validate()
+			if tt.errMsgPt != "" {
+				if !assert.Error(err) {
+					return
+				}
+				assert.Regexp(tt.errMsgPt, err.Error())
+				return
+			}
+			assert.NoError(err)
+		})
+	}
+}

--- a/models/ids/task_test.go
+++ b/models/ids/task_test.go
@@ -1,0 +1,131 @@
+package ids_test
+
+import (
+	"testing"
+
+	"github.com/meian/atgo/models/ids"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTaskID_Validate(t *testing.T) {
+	tests := []struct {
+		name     string
+		id       ids.TaskID
+		errMsgPt string
+	}{
+		{
+			name:     "success",
+			id:       "abc123_a",
+			errMsgPt: "",
+		},
+		{
+			name:     "not contains _",
+			id:       "abc123",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "empty",
+			id:       "",
+			errMsgPt: `empty id`,
+		},
+		{
+			name:     "64 chars",
+			id:       "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_a",
+			errMsgPt: "",
+		},
+		{
+			name:     "65 chars",
+			id:       "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_ab",
+			errMsgPt: `is too long`,
+		},
+		{
+			name:     "first char is -",
+			id:       "-abc123_a",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "last char is -",
+			id:       "abc123_a-",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains -",
+			id:       "abc-123_a",
+			errMsgPt: "",
+		},
+		{
+			name:     "double -",
+			id:       "abc--123_a",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "first char is _",
+			id:       "_abc123_a",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "last char is _",
+			id:       "abc123_a_",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains _",
+			id:       "abc_123_a",
+			errMsgPt: "",
+		},
+		{
+			name:     "double _",
+			id:       "abc__123_a",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains double - and _",
+			id:       "abc-_123_a",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains symbol",
+			id:       "abc!123_a",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains space",
+			id:       "abc 123_a",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains tab",
+			id:       "abc\t123_a",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains newline",
+			id:       "abc\n123_a",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "contains carriage return",
+			id:       "abc\r123_a",
+			errMsgPt: `invalid .+ format:`,
+		},
+		{
+			name:     "multi byte",
+			id:       "ａｂｃ１２３_ａ",
+			errMsgPt: `invalid .+ format:`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			err := tt.id.Validate()
+			if tt.errMsgPt != "" {
+				if !assert.Error(err) {
+					return
+				}
+				assert.Regexp(tt.errMsgPt, err.Error())
+				return
+			}
+			assert.NoError(err)
+		})
+	}
+}

--- a/models/task.go
+++ b/models/task.go
@@ -3,11 +3,12 @@ package models
 import (
 	"time"
 
+	"github.com/meian/atgo/models/ids"
 	"gopkg.in/guregu/null.v3"
 )
 
 type Task struct {
-	ID        string        `gorm:"primaryKey"`
+	ID        ids.TaskID    `gorm:"primaryKey"`
 	Title     string        `gorm:"not null"`
 	TimeLimit time.Duration `gorm:"type:integer;not null"`
 	Memory    int           `gorm:"not null"`

--- a/models/task_info.go
+++ b/models/task_info.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/meian/atgo/files"
 	"github.com/meian/atgo/io"
+	"github.com/meian/atgo/models/ids"
 	"github.com/meian/atgo/url"
 	"github.com/meian/atgo/workspace"
 	"github.com/pkg/errors"
@@ -18,12 +19,12 @@ type taskYAML struct {
 }
 
 type TaskInfo struct {
-	ContestID string `yaml:"contest-id"`
-	TaskID    string `yaml:"task-id"`
+	ContestID ids.ContestID `yaml:"contest-id"`
+	TaskID    ids.TaskID    `yaml:"task-id"`
 }
 
 func (ti TaskInfo) TaskDir() string {
-	return filepath.Join(workspace.TaskRootDir(), ti.ContestID, ti.TaskID)
+	return filepath.Join(workspace.TaskRootDir(), string(ti.ContestID), string(ti.TaskID))
 }
 
 func (ti TaskInfo) TaskURL() string {

--- a/models/task_sample.go
+++ b/models/task_sample.go
@@ -1,5 +1,7 @@
 package models
 
+import "github.com/meian/atgo/models/ids"
+
 type TaskSampleType int
 
 const (
@@ -8,12 +10,12 @@ const (
 )
 
 type TaskSample struct {
-	ID     string         `gorm:"primaryKey"`
-	TaskID string         `gorm:"not null"`
-	Index  string         `gorm:"not null"`
-	Input  string         `gorm:"not null"`
-	Output string         `gorm:"not null"`
-	Type   TaskSampleType `gorm:"not null"`
+	ID     ids.TaskSampleID `gorm:"primaryKey"`
+	TaskID ids.TaskID       `gorm:"not null"`
+	Index  string           `gorm:"not null"`
+	Input  string           `gorm:"not null"`
+	Output string           `gorm:"not null"`
+	Type   TaskSampleType   `gorm:"not null"`
 }
 
 func init() {

--- a/url/url.go
+++ b/url/url.go
@@ -3,6 +3,8 @@ package url
 import (
 	"net/url"
 	"strings"
+
+	"github.com/meian/atgo/models/ids"
 )
 
 const (
@@ -30,23 +32,23 @@ func ContestArchiveURL() string {
 	return URL(ContestArchivePath, nil, nil).String()
 }
 
-func ContestURL(contestID string) string {
-	pathParams := map[string]string{"contestID": contestID}
+func ContestURL(contestID ids.ContestID) string {
+	pathParams := map[string]string{"contestID": string(contestID)}
 	return URL(ContestPath, pathParams, nil).String()
 }
 
-func ContestTaskURL(contestID string) string {
-	pathParams := map[string]string{"contestID": contestID}
+func ContestTaskURL(contestID ids.ContestID) string {
+	pathParams := map[string]string{"contestID": string(contestID)}
 	return URL(ContestTaskPath, pathParams, nil).String()
 }
 
-func TaskURL(contestID string, taskID string) string {
-	pathParams := map[string]string{"contestID": contestID, "id": taskID}
+func TaskURL(contestID ids.ContestID, taskID ids.TaskID) string {
+	pathParams := map[string]string{"contestID": string(contestID), "id": string(taskID)}
 	return URL(TaskPath, pathParams, nil).String()
 }
 
-func MySubmissionURL(contestID string) string {
-	pathParams := map[string]string{"contestID": contestID}
+func MySubmissionURL(contestID ids.ContestID) string {
+	pathParams := map[string]string{"contestID": string(contestID)}
 	return URL(MySubmissionPath, pathParams, nil).String()
 }
 

--- a/usecase/common/resolve_task_info.go
+++ b/usecase/common/resolve_task_info.go
@@ -7,6 +7,7 @@ import (
 	"github.com/meian/atgo/io"
 	"github.com/meian/atgo/logs"
 	"github.com/meian/atgo/models"
+	"github.com/meian/atgo/models/ids"
 	"github.com/meian/atgo/workspace"
 )
 
@@ -15,12 +16,12 @@ func ResolveTaskInfo(ctx context.Context, contestID, taskID string) (*models.Tas
 	if len(taskID) > 0 {
 		logger = logger.With("taskID", taskID)
 		if len(contestID) == 0 {
-			cID, err := models.DetectContestID(taskID)
+			cID, err := models.DetectContestID(ids.TaskID(taskID))
 			if err != nil {
 				logger.Error(err.Error())
 				return nil, false, errors.New("failed to detect contest ID from task ID")
 			}
-			contestID = cID
+			contestID = string(cID)
 		}
 	}
 
@@ -41,8 +42,8 @@ func ResolveTaskInfo(ctx context.Context, contestID, taskID string) (*models.Tas
 			return nil, false, errors.New("failed to find task info file")
 		}
 		return &models.TaskInfo{
-			ContestID: contestID,
-			TaskID:    taskID,
+			ContestID: ids.ContestID(contestID),
+			TaskID:    ids.TaskID(taskID),
 		}, true, nil
 	}
 	var info models.TaskInfo
@@ -54,15 +55,15 @@ func ResolveTaskInfo(ctx context.Context, contestID, taskID string) (*models.Tas
 		return nil, false, errors.New("cannot get contest ID from task info file")
 	}
 	if len(contestID) > 0 {
-		if info.ContestID != contestID {
-			info.ContestID = contestID
-			info.TaskID = taskID
+		if info.ContestID != ids.ContestID(contestID) {
+			info.ContestID = ids.ContestID(contestID)
+			info.TaskID = ids.TaskID(taskID)
 			mustSave = true
 		}
 	}
 	if len(taskID) > 0 {
-		if info.TaskID != taskID {
-			info.TaskID = taskID
+		if info.TaskID != ids.TaskID(taskID) {
+			info.TaskID = ids.TaskID(taskID)
 			mustSave = true
 		}
 	}

--- a/usecase/contest.go
+++ b/usecase/contest.go
@@ -36,13 +36,13 @@ func (u Contest) Run(ctx context.Context, param ContestParam) (*ContestResult, e
 	logger = logger.With("contestID", info.ContestID)
 	ctx = logs.ContextWith(ctx, logger)
 
-	contest, err := repo.Find(ctx, info.ContestID)
+	contest, err := repo.Find(ctx, string(info.ContestID))
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, errors.New("failed to find contest")
 	}
 	if contest == nil {
-		contest, err = u.createContest(ctx, info.ContestID)
+		contest, err = u.createContest(ctx, string(info.ContestID))
 		if err != nil {
 			return nil, err
 		}
@@ -54,13 +54,13 @@ func (u Contest) Run(ctx context.Context, param ContestParam) (*ContestResult, e
 		}
 	}
 
-	contest, err = repo.FindWithTasks(ctx, info.ContestID)
+	contest, err = repo.FindWithTasks(ctx, string(info.ContestID))
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, errors.New("failed to find contest with tasks")
 	}
 
-	if param.ContestID != info.ContestID {
+	if param.ContestID != string(info.ContestID) {
 		taskFile, _ := workspace.TaskInfoFile()
 		if err := info.WriteFile(taskFile); err != nil {
 			logger.Error(err.Error())
@@ -101,7 +101,7 @@ func (u Contest) createContest(ctx context.Context, contestID string) (*models.C
 func (u Contest) loadTasks(ctx context.Context, contest *models.Contest) error {
 	logger := logs.FromContext(ctx)
 	client := http.ClientFromContext(ctx)
-	req := requests.ContestTask{ContestID: contest.ID}
+	req := requests.ContestTask{ContestID: string(contest.ID)}
 	res, err := crawler.NewContestTask(client).Do(ctx, req)
 	if err != nil {
 		logger.Error(err.Error())

--- a/usecase/contest_load.go
+++ b/usecase/contest_load.go
@@ -10,6 +10,7 @@ import (
 	"github.com/meian/atgo/http"
 	"github.com/meian/atgo/logs"
 	"github.com/meian/atgo/models"
+	"github.com/meian/atgo/models/ids"
 	"github.com/meian/atgo/repo"
 	"github.com/meian/atgo/util"
 	"github.com/pkg/errors"
@@ -56,7 +57,7 @@ func (u ContestLoad) Run(ctx context.Context, param ContestLoadParam) (*ContestL
 		return nil, errors.New("failed to find contests")
 	}
 	contestm := util.ToMap(contests, func(c models.Contest) string {
-		return c.ID
+		return string(c.ID)
 	})
 
 	ratedType := param.RatedType.String()
@@ -68,7 +69,7 @@ func (u ContestLoad) Run(ctx context.Context, param ContestLoadParam) (*ContestL
 		if !ok {
 			logger.Debug("new contest")
 			newContests = append(newContests, models.Contest{
-				ID:         contest.ID,
+				ID:         ids.ContestID(contest.ID),
 				Title:      contest.Title,
 				StartAt:    contest.StartAt,
 				Duration:   contest.Duration,

--- a/usecase/submit.go
+++ b/usecase/submit.go
@@ -113,8 +113,8 @@ func (u Submit) login(ctx context.Context, info models.TaskInfo) (bool, string, 
 	logger := logs.FromContext(ctx)
 	client := http.ClientFromContext(ctx)
 	req := requests.Task{
-		ContestID: info.ContestID,
-		TaskID:    info.TaskID,
+		ContestID: string(info.ContestID),
+		TaskID:    string(info.TaskID),
 	}
 	res, err := crawler.NewTask(client).Do(ctx, req)
 	if err != nil {
@@ -200,8 +200,8 @@ func (u Submit) submit(ctx context.Context, info *models.TaskInfo, source string
 	logger := logs.FromContext(ctx)
 	client := http.ClientFromContext(ctx)
 	req := &requests.Submit{
-		ContestID:  info.ContestID,
-		TaskID:     info.TaskID,
+		ContestID:  string(info.ContestID),
+		TaskID:     string(info.TaskID),
 		LanguageID: constant.LanguageGo_1_20_6,
 		SourceCode: source,
 		CSRFToken:  csrfToken,

--- a/usecase/task_local_init.go
+++ b/usecase/task_local_init.go
@@ -64,8 +64,8 @@ func (u TaskLocalInit) Run(ctx context.Context, param TaskLocalInitParam) (*Task
 			return nil, errors.New("failed to restore task files")
 		}
 		return &TaskLocalInitResult{
-			ContestID: contest.ID,
-			TaskID:    task.ID,
+			ContestID: string(contest.ID),
+			TaskID:    string(task.ID),
 			New:       false,
 		}, nil
 	}
@@ -137,8 +137,8 @@ func (u TaskLocalInit) Run(ctx context.Context, param TaskLocalInitParam) (*Task
 	}
 
 	return &TaskLocalInitResult{
-		ContestID: contest.ID,
-		TaskID:    task.ID,
+		ContestID: string(contest.ID),
+		TaskID:    string(task.ID),
 		New:       true,
 	}, nil
 }


### PR DESCRIPTION
DBテーブルに対応する各モデルのIDをstringから固有のValueObjectに変更しました

- ids パッケージ配下に各IDのValueObjectを定義
- 各IDは id.Validate で値の正当性を評価できる
- テーブルモデルでIDを参照する値にValueObjectを適用
- テンプレート内関数がgenericsにしていないので、mapFuncsで扱う関数へのID引数をValueObjectに変更
- テンプレートに出力するモデルのIDにValueObjectを適用

@coderabbitai

idsパッケージ以外で型を変更している箇所は基本的にロジックの変更は一切ない想定です。  
もしロジックが変更されている箇所があればそれも合わせて指摘してください

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- IDフィールドの型を`string`から新しいID型（`ids.ContestID`, `ids.TaskID`など）に変更し、型安全性を向上。
	- 新しいID管理パッケージを導入し、各IDのバリデーション機能を追加。

- **バグ修正**
	- 各所でIDの扱いを統一し、潜在的なエラーを減少。

- **ドキュメント**
	- 新しく追加されたID関連の構造体とメソッドに関するテストを追加。

- **リファクタリング**
	- ID関連の処理をセマンティックに改善し、コードの可読性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->