### PR TITLE
crawler/requests 内のエラーの定義を1ファイルにまとめて共有するように変更した

### DIFF
--- a/crawler/requests/contest.go
+++ b/crawler/requests/contest.go
@@ -1,14 +1,12 @@
 package requests
 
-import "github.com/pkg/errors"
-
 type Contest struct {
 	ContestID string
 }
 
 func (r Contest) Validate() error {
 	if r.ContestID == "" {
-		return errors.New("contest id is required")
+		return ErrReqContestID
 	}
 	return nil
 }

--- a/crawler/requests/contest_archive.go
+++ b/crawler/requests/contest_archive.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/meian/atgo/constant"
-	"github.com/pkg/errors"
 )
 
 type ContestArchive struct {
@@ -17,13 +16,13 @@ type ContestArchive struct {
 
 func (r ContestArchive) Validate() error {
 	if r.Page <= 0 {
-		return errors.New("page must be greater than 0")
+		return ErrPageGT0
 	}
 	if r.RatedType != nil && !r.RatedType.IsARatedType() {
-		return errors.Errorf("invalid rated type: %d", r.RatedType)
+		return ErrInvalidRatedType(*r.RatedType)
 	}
 	if r.Category != nil && !r.Category.IsAContestCategory() {
-		return errors.Errorf("invalid category: %d", r.Category)
+		return ErrInvalidCategory(*r.Category)
 	}
 	return nil
 }

--- a/crawler/requests/contest_task.go
+++ b/crawler/requests/contest_task.go
@@ -1,14 +1,12 @@
 package requests
 
-import "github.com/pkg/errors"
-
 type ContestTask struct {
 	ContestID string
 }
 
 func (r ContestTask) Validate() error {
 	if r.ContestID == "" {
-		return errors.New("contest id is required")
+		return ErrReqContestID
 	}
 	return nil
 }

--- a/crawler/requests/errors.go
+++ b/crawler/requests/errors.go
@@ -1,0 +1,29 @@
+package requests
+
+import (
+	"github.com/meian/atgo/constant"
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrReqContestID  = newRequiredError("Contest ID")
+	ErrReqTaskID     = newRequiredError("Task ID")
+	ErrReqSourceCode = newRequiredError("Source code")
+	ErrReqCSRFToken  = newRequiredError("CSRF token")
+
+	ErrPageGT0 = errors.New("Page must be greater than 0")
+
+	ErrInvalidRatedType  = newInvalidErrorFunc[constant.RatedType]("rated type")
+	ErrInvalidCategory   = newInvalidErrorFunc[constant.ContestCategory]("category")
+	ErrInvalidLanguageID = newInvalidErrorFunc[constant.LanguageID]("language ID")
+)
+
+func newRequiredError(name string) error {
+	return errors.Errorf("%s is required", name)
+}
+
+func newInvalidErrorFunc[T any](name string) func(value T) error {
+	return func(value T) error {
+		return errors.Errorf("Invalid %s: %v", name, value)
+	}
+}

--- a/crawler/requests/submit.go
+++ b/crawler/requests/submit.go
@@ -4,7 +4,6 @@ import (
 	"net/url"
 
 	"github.com/meian/atgo/constant"
-	"github.com/pkg/errors"
 )
 
 type Submit struct {
@@ -17,19 +16,19 @@ type Submit struct {
 
 func (r Submit) Validate() error {
 	if r.ContestID == "" {
-		return errors.New("contest id is required")
+		return ErrReqContestID
 	}
 	if r.TaskID == "" {
-		return errors.New("task id is required")
+		return ErrReqTaskID
 	}
 	if !r.LanguageID.Valid() {
-		return errors.Errorf("invalid language id: %d", r.LanguageID)
+		return ErrInvalidLanguageID(r.LanguageID)
 	}
 	if r.SourceCode == "" {
-		return errors.New("source code is required")
+		return ErrReqSourceCode
 	}
 	if r.CSRFToken == "" {
-		return errors.New("csrf token is required")
+		return ErrReqCSRFToken
 	}
 	return nil
 }

--- a/crawler/requests/task.go
+++ b/crawler/requests/task.go
@@ -1,7 +1,5 @@
 package requests
 
-import "github.com/pkg/errors"
-
 type Task struct {
 	ContestID string
 	TaskID    string
@@ -9,10 +7,10 @@ type Task struct {
 
 func (r Task) Validate() error {
 	if r.ContestID == "" {
-		return errors.New("contest id is required")
+		return ErrReqContestID
 	}
 	if r.TaskID == "" {
-		return errors.New("task id is required")
+		return ErrReqTaskID
 	}
 	return nil
 }


### PR DESCRIPTION
https://github.com/meian/atgo/pull/99#discussion_r1707087775 で指摘されたエラーメッセージについて、以下のように変更しました。

- メッセージの書式がある程度同じなので1箇所でまとめて定義した
- メッセージの先頭が大文字で始まるようにした
- IDやCSRFなどの略語をすべて大文字にした


@coderabbitai  
修正内容に問題がないか確認をお願いします