### PR TITLE
repo配下でIDのValueObjectを利用するように変更

### DIFF
--- a/models/ids/common.go
+++ b/models/ids/common.go
@@ -2,7 +2,7 @@ package ids
 
 import "errors"
 
-type modelID interface {
+type ModelID interface {
 	~string
 	Validate() error
 }
@@ -24,7 +24,7 @@ func (e errInvalidFormat) String() string {
 	return e.Error()
 }
 
-func newErrInvalidFormat[ID modelID](label string, id ID) error {
+func newErrInvalidFormat[ID ModelID](label string, id ID) error {
 	return errInvalidFormat{label: label, id: string(id)}
 }
 
@@ -41,7 +41,7 @@ func (e errTooLong) String() string {
 	return e.Error()
 }
 
-func validateLen[ID modelID](label string, id ID) error {
+func validateLen[ID ModelID](label string, id ID) error {
 	if len(id) > 64 {
 		return errTooLong{label: label, id: string(id)}
 	}

--- a/models/ids/rated_type.go
+++ b/models/ids/rated_type.go
@@ -1,0 +1,19 @@
+package ids
+
+import "slices"
+
+type RatedType string
+
+var (
+	ratedTypes = []RatedType{"abc", "arc", "agc", "ahc"}
+)
+
+func (t RatedType) Validate() error {
+	if t == "" {
+		return ErrEmptyID
+	}
+	if !slices.Contains(ratedTypes, t) {
+		return newErrInvalidFormat("rated type", t)
+	}
+	return nil
+}

--- a/models/ids/rated_type_test.go
+++ b/models/ids/rated_type_test.go
@@ -1,0 +1,71 @@
+package ids_test
+
+import (
+	"testing"
+
+	"github.com/meian/atgo/models/ids"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRatedType_Validate(t *testing.T) {
+	tests := []struct {
+		name     string
+		rt       ids.RatedType
+		errMsgPt string
+	}{
+		{
+			name:     "abc",
+			rt:       "abc",
+			errMsgPt: "",
+		},
+		{
+			name:     "arc",
+			rt:       "arc",
+			errMsgPt: "",
+		},
+		{
+			name:     "agc",
+			rt:       "agc",
+			errMsgPt: "",
+		},
+		{
+			name:     "ahc",
+			rt:       "ahc",
+			errMsgPt: "",
+		},
+		{
+			name:     "not defined",
+			rt:       "xyz",
+			errMsgPt: `invalid .+ format: xyz`,
+		},
+		{
+			name:     "upper case",
+			rt:       "ABC",
+			errMsgPt: `invalid .+ format: ABC`,
+		},
+		{
+			name:     "upper first",
+			rt:       "Abc",
+			errMsgPt: `invalid .+ format: Abc`,
+		},
+		{
+			name:     "empty",
+			rt:       "",
+			errMsgPt: `empty id`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			err := tt.rt.Validate()
+			if tt.errMsgPt != "" {
+				if !assert.Error(err) {
+					return
+				}
+				assert.Regexp(tt.errMsgPt, err.Error())
+				return
+			}
+			assert.NoError(err)
+		})
+	}
+}

--- a/models/rated_type.go
+++ b/models/rated_type.go
@@ -1,7 +1,9 @@
 package models
 
+import "github.com/meian/atgo/models/ids"
+
 type RatedType struct {
-	Type string `gorm:"primary_key"`
+	Type ids.RatedType `gorm:"primary_key"`
 
 	Contests []Contest `gorm:"foreignKey:RatedType;constraint:OnDelete:CASCADE"`
 }

--- a/repo/contest.go
+++ b/repo/contest.go
@@ -3,7 +3,6 @@ package repo
 import (
 	"context"
 
-	"github.com/meian/atgo/constant"
 	"github.com/meian/atgo/database"
 	"github.com/meian/atgo/logs"
 	"github.com/meian/atgo/models"
@@ -34,7 +33,7 @@ func (r *Contest) Search(ctx context.Context, p *params.Contest) ([]models.Conte
 	}
 	var contests []models.Contest
 	query := r.DBConn.DB()
-	if p.RatedType != nil && *p.RatedType != constant.RatedTypeAll.String() {
+	if p.RatedType != nil {
 		query = query.Where("rated_type = ?", p.RatedType)
 	}
 	query = query.Order("start_at DESC")

--- a/repo/contest.go
+++ b/repo/contest.go
@@ -6,13 +6,14 @@ import (
 	"github.com/meian/atgo/database"
 	"github.com/meian/atgo/logs"
 	"github.com/meian/atgo/models"
+	"github.com/meian/atgo/models/ids"
 	"github.com/meian/atgo/repo/params"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 )
 
 type Contest struct {
-	*repository[models.Contest]
+	*repository[models.Contest, ids.ContestID]
 }
 
 func NewContest(db *gorm.DB) *Contest {
@@ -20,7 +21,7 @@ func NewContest(db *gorm.DB) *Contest {
 }
 
 func NewContestWithDBConn(dbConn *database.DBConn) *Contest {
-	return &Contest{newRepositoryWithDBConn[models.Contest](dbConn)}
+	return &Contest{newRepositoryWithDBConn[models.Contest, ids.ContestID](dbConn)}
 }
 
 func (r *Contest) Search(ctx context.Context, p *params.Contest) ([]models.Contest, error) {
@@ -45,7 +46,7 @@ func (r *Contest) Search(ctx context.Context, p *params.Contest) ([]models.Conte
 	return contests, nil
 }
 
-func (r *Contest) FindWithTasks(ctx context.Context, id string) (*models.Contest, error) {
+func (r *Contest) FindWithTasks(ctx context.Context, id ids.ContestID) (*models.Contest, error) {
 	var contest models.Contest
 	err := r.DBConn.DB().
 		Preload("ContestTasks", func(db *gorm.DB) *gorm.DB {
@@ -64,7 +65,7 @@ func (r *Contest) FindWithTasks(ctx context.Context, id string) (*models.Contest
 	return &contest, nil
 }
 
-func (r *Contest) FindByIDs(ctx context.Context, ids []string) ([]models.Contest, error) {
+func (r *Contest) FindByIDs(ctx context.Context, ids []ids.ContestID) ([]models.Contest, error) {
 	var contests []models.Contest
 	if err := r.DBConn.DB().Where("id IN (?)", ids).Find(&contests).Error; err != nil {
 		return nil, errors.Wrapf(err, "failed to find contests: ids=%v", ids)

--- a/repo/contest_task.go
+++ b/repo/contest_task.go
@@ -6,12 +6,13 @@ import (
 	"github.com/meian/atgo/database"
 	"github.com/meian/atgo/logs"
 	"github.com/meian/atgo/models"
+	"github.com/meian/atgo/models/ids"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 )
 
 type ContestTask struct {
-	*repository[models.ContestTask]
+	*repository[models.ContestTask, ids.ContestTaskID]
 }
 
 func NewContestTask(db *gorm.DB) *ContestTask {
@@ -19,10 +20,10 @@ func NewContestTask(db *gorm.DB) *ContestTask {
 }
 
 func NewContestTaskWithDBConn(dbConn *database.DBConn) *ContestTask {
-	return &ContestTask{newRepositoryWithDBConn[models.ContestTask](dbConn)}
+	return &ContestTask{newRepositoryWithDBConn[models.ContestTask, ids.ContestTaskID](dbConn)}
 }
 
-func (r *ContestTask) FindByIDs(ctx context.Context, contestID, taskID string) (*models.ContestTask, error) {
+func (r *ContestTask) FindByIDs(ctx context.Context, contestID ids.ContestID, taskID ids.TaskID) (*models.ContestTask, error) {
 	var contestTask models.ContestTask
 	err := r.DBConn.DB().
 		Preload("Task").

--- a/repo/params/contest.go
+++ b/repo/params/contest.go
@@ -2,16 +2,15 @@ package params
 
 import (
 	"context"
-	"slices"
 
-	"github.com/meian/atgo/constant"
 	"github.com/meian/atgo/logs"
+	"github.com/meian/atgo/models/ids"
 	"github.com/pkg/errors"
 )
 
 type Contest struct {
 	*baseParam
-	RatedType *string
+	RatedType *ids.RatedType
 }
 
 func NewContest() *Contest {
@@ -21,9 +20,11 @@ func NewContest() *Contest {
 }
 
 func (p *Contest) Validate(ctx context.Context) error {
-	if p.RatedType != nil && !slices.Contains(constant.RatedTypeStrings(), *p.RatedType) {
-		logs.FromContext(ctx).With("ratedType", p.RatedType).Error("undefined type")
-		return errors.New("invalid rated type")
+	if p.RatedType != nil {
+		if err := p.RatedType.Validate(); err != nil {
+			logs.FromContext(ctx).Error(err.Error())
+			return errors.New("invalid rated type")
+		}
 	}
 	if err := p.baseParam.Validate(ctx); err != nil {
 		return err

--- a/repo/rated_type.go
+++ b/repo/rated_type.go
@@ -3,11 +3,12 @@ package repo
 import (
 	"github.com/meian/atgo/database"
 	"github.com/meian/atgo/models"
+	"github.com/meian/atgo/models/ids"
 	"gorm.io/gorm"
 )
 
 type RatedType struct {
-	*repository[models.RatedType]
+	*repository[models.RatedType, ids.RatedType]
 }
 
 func NewRateType(db *gorm.DB) *RatedType {
@@ -15,5 +16,5 @@ func NewRateType(db *gorm.DB) *RatedType {
 }
 
 func NewRatedTypeWithDBConn(dbConn *database.DBConn) *RatedType {
-	return &RatedType{newRepositoryWithDBConn[models.RatedType](dbConn)}
+	return &RatedType{newRepositoryWithDBConn[models.RatedType, ids.RatedType](dbConn)}
 }

--- a/repo/repository.go
+++ b/repo/repository.go
@@ -4,20 +4,21 @@ import (
 	"context"
 
 	"github.com/meian/atgo/database"
+	"github.com/meian/atgo/models/ids"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
 
-type repository[M any] struct {
+type repository[M any, ID ids.ModelID] struct {
 	DBConn *database.DBConn
 }
 
-func newRepositoryWithDBConn[M any](dbConn *database.DBConn) *repository[M] {
-	return &repository[M]{dbConn}
+func newRepositoryWithDBConn[M any, ID ids.ModelID](dbConn *database.DBConn) *repository[M, ID] {
+	return &repository[M, ID]{dbConn}
 }
 
-func (r *repository[M]) Find(ctx context.Context, id string) (*M, error) {
+func (r *repository[M, ID]) Find(ctx context.Context, id ID) (*M, error) {
 	var m M
 	err := r.DBConn.DB().Omit(clause.Associations).Where("id = ?", id).First(&m).Error
 	if err != nil {
@@ -29,31 +30,31 @@ func (r *repository[M]) Find(ctx context.Context, id string) (*M, error) {
 	return &m, nil
 }
 
-func (r *repository[M]) Create(ctx context.Context, model *M) error {
+func (r *repository[M, ID]) Create(ctx context.Context, model *M) error {
 	return r.DBConn.DB().Omit(clause.Associations).Create(model).Error
 }
 
-func (r *repository[M]) CreateBatch(ctx context.Context, models []M) error {
+func (r *repository[M, ID]) CreateBatch(ctx context.Context, models []M) error {
 	return r.DBConn.DB().Omit(clause.Associations).Create(models).Error
 }
 
-func (r *repository[M]) Update(ctx context.Context, model *M) error {
+func (r *repository[M, ID]) Update(ctx context.Context, model *M) error {
 	return r.DBConn.DB().Omit(clause.Associations).Save(model).Error
 }
 
-func (r *repository[M]) UpdateWithChilds(ctx context.Context, models *M) error {
+func (r *repository[M, ID]) UpdateWithChilds(ctx context.Context, models *M) error {
 	return r.DBConn.DB().Save(models).Error
 }
 
-func (r *repository[M]) TableName() string {
+func (r *repository[M, ID]) TableName() string {
 	var m M
 	return database.TableName(r.DBConn.DB(), m)
 }
 
-func (r *repository[M]) Truncate(ctx context.Context) error {
+func (r *repository[M, ID]) Truncate(ctx context.Context) error {
 	return r.DBConn.DB().Exec("DELETE FROM " + r.TableName()).Error
 }
 
-func (r *repository[M]) Tx(f func(conn *database.DBConn) error) error {
+func (r *repository[M, ID]) Tx(f func(conn *database.DBConn) error) error {
 	return r.DBConn.Transaction(f)
 }

--- a/repo/task.go
+++ b/repo/task.go
@@ -6,12 +6,13 @@ import (
 	"github.com/meian/atgo/database"
 	"github.com/meian/atgo/logs"
 	"github.com/meian/atgo/models"
+	"github.com/meian/atgo/models/ids"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 )
 
 type Task struct {
-	*repository[models.Task]
+	*repository[models.Task, ids.TaskID]
 }
 
 func NewTask(db *gorm.DB) *Task {
@@ -19,10 +20,10 @@ func NewTask(db *gorm.DB) *Task {
 }
 
 func NewTaskWithDBConn(dbConn *database.DBConn) *Task {
-	return &Task{newRepositoryWithDBConn[models.Task](dbConn)}
+	return &Task{newRepositoryWithDBConn[models.Task, ids.TaskID](dbConn)}
 }
 
-func (r *Task) FindWithSamples(ctx context.Context, taskID string) (*models.Task, error) {
+func (r *Task) FindWithSamples(ctx context.Context, taskID ids.TaskID) (*models.Task, error) {
 	var task models.Task
 	err := r.DBConn.DB().
 		Preload("Samples").

--- a/usecase/contest.go
+++ b/usecase/contest.go
@@ -36,7 +36,7 @@ func (u Contest) Run(ctx context.Context, param ContestParam) (*ContestResult, e
 	logger = logger.With("contestID", info.ContestID)
 	ctx = logs.ContextWith(ctx, logger)
 
-	contest, err := repo.Find(ctx, string(info.ContestID))
+	contest, err := repo.Find(ctx, info.ContestID)
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, errors.New("failed to find contest")
@@ -54,7 +54,7 @@ func (u Contest) Run(ctx context.Context, param ContestParam) (*ContestResult, e
 		}
 	}
 
-	contest, err = repo.FindWithTasks(ctx, string(info.ContestID))
+	contest, err = repo.FindWithTasks(ctx, info.ContestID)
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, errors.New("failed to find contest with tasks")

--- a/usecase/contest_list.go
+++ b/usecase/contest_list.go
@@ -6,8 +6,10 @@ import (
 	"github.com/meian/atgo/database"
 	"github.com/meian/atgo/logs"
 	"github.com/meian/atgo/models"
+	"github.com/meian/atgo/models/ids"
 	"github.com/meian/atgo/repo"
 	"github.com/meian/atgo/repo/params"
+	"github.com/meian/atgo/util"
 	"github.com/pkg/errors"
 )
 
@@ -25,7 +27,7 @@ type ContestListResult struct {
 
 func (u ContestList) Run(ctx context.Context, param ContestListParam) (*ContestListResult, error) {
 	p := params.NewContest()
-	p.RatedType = &param.RatedType
+	p.RatedType = util.ToPtr(ids.RatedType(param.RatedType))
 	p.Page = param.Page
 	p.Size = param.Size
 	contests, err := repo.NewContest(database.FromContext(ctx)).Search(ctx, p)

--- a/usecase/contest_load.go
+++ b/usecase/contest_load.go
@@ -45,9 +45,13 @@ func (u ContestLoad) Run(ctx context.Context, param ContestLoadParam) (*ContestL
 		return nil, errors.New("failed to list contests")
 	}
 
-	cids := res.Contests.IDs()
-	if len(cids) == 0 {
+	contestIDs := res.Contests.IDs()
+	if len(contestIDs) == 0 {
 		return nil, errors.New("no archived contests.")
+	}
+	cids := make([]ids.ContestID, len(contestIDs))
+	for i, id := range contestIDs {
+		cids[i] = ids.ContestID(id)
 	}
 	logger = logger.With("totalPages", res.TotalPages)
 	crepo := repo.NewContest(database.FromContext(ctx))

--- a/usecase/init.go
+++ b/usecase/init.go
@@ -6,6 +6,7 @@ import (
 	"github.com/meian/atgo/database"
 	"github.com/meian/atgo/logs"
 	"github.com/meian/atgo/models"
+	"github.com/meian/atgo/models/ids"
 	"github.com/meian/atgo/repo"
 	"github.com/meian/atgo/workspace"
 	"github.com/pkg/errors"
@@ -64,7 +65,7 @@ func (u Init) Run(ctx context.Context, param InitParam) (*InitResult, error) {
 		logger.Error(err.Error())
 		return nil, errors.New("failed to create rated types")
 	}
-	ss := make([]string, len(ratedTypes))
+	ss := make([]ids.RatedType, len(ratedTypes))
 	for i, rt := range ratedTypes {
 		ss[i] = rt.Type
 	}

--- a/usecase/task.go
+++ b/usecase/task.go
@@ -45,7 +45,7 @@ func (u Task) Run(ctx context.Context, param TaskParam) (*TaskResult, error) {
 	ctrepo := repo.NewContestTaskWithDBConn(dbConn)
 	trepo := repo.NewTaskWithDBConn(dbConn)
 
-	task, err := trepo.Find(ctx, string(info.TaskID))
+	task, err := trepo.Find(ctx, info.TaskID)
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, errors.New("failed to find task")
@@ -64,7 +64,7 @@ func (u Task) Run(ctx context.Context, param TaskParam) (*TaskResult, error) {
 		}
 	}
 
-	contest, err := crepo.Find(ctx, string(info.ContestID))
+	contest, err := crepo.Find(ctx, info.ContestID)
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, errors.New("failed to find contest")
@@ -76,7 +76,7 @@ func (u Task) Run(ctx context.Context, param TaskParam) (*TaskResult, error) {
 			return nil, errors.New("failed to create contest")
 		}
 	}
-	ct, err := ctrepo.FindByIDs(ctx, string(info.ContestID), string(info.TaskID))
+	ct, err := ctrepo.FindByIDs(ctx, info.ContestID, info.TaskID)
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, errors.New("failed to find contest task")
@@ -85,7 +85,7 @@ func (u Task) Run(ctx context.Context, param TaskParam) (*TaskResult, error) {
 		return nil, errors.New("the specified contest and task are not related")
 	}
 	if param.ShowSamples {
-		task, err = trepo.FindWithSamples(ctx, string(info.TaskID))
+		task, err = trepo.FindWithSamples(ctx, info.TaskID)
 	} else {
 		task.Samples = nil
 	}
@@ -130,7 +130,7 @@ func (u Task) createTask(ctx context.Context, contestID string, taskID string) (
 	logger := logs.FromContext(ctx)
 
 	ctx = logs.ContextWith(ctx, logger)
-	contest, err := repo.NewContest(database.FromContext(ctx)).Find(ctx, contestID)
+	contest, err := repo.NewContest(database.FromContext(ctx)).Find(ctx, ids.ContestID(contestID))
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, errors.New("failed to find contest")
@@ -148,7 +148,7 @@ func (u Task) createTask(ctx context.Context, contestID string, taskID string) (
 		}
 	}
 
-	task, err := repo.NewTask(database.FromContext(ctx)).Find(ctx, taskID)
+	task, err := repo.NewTask(database.FromContext(ctx)).Find(ctx, ids.TaskID(taskID))
 	if err != nil {
 		logger.Error(err.Error())
 		return nil, errors.New("failed to find task")


### PR DESCRIPTION
repo配下でIDを引き渡す箇所をIDのValueObjectで引き渡すように変更しました  
それに合わせて不足部分を調整しています。

- ids配下のインターフェイスを公開した
- rated_types.type についてID型同様のValueObjectを定義した
- repositoryの型パラメータを[model, id] として、Findの引数でID型を渡すようにした

@coderabbitai

周辺の影響としてrepoのメソッドやフィールドにアクセスする外部パッケージも動作が変わらない範囲で修正しています。  
何か動作が変更するような修正が混じっている場合はそれも合わせて指摘してください

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- `RatedType` に対するバリデーション機能を追加し、有効な識別子のセットを管理。
	- 複数のエンティティで新しい型 `ids` を採用し、型の安全性を向上。
  
- **改善**
	- `Contest` と `Task` における識別子の扱いを簡素化し、型変換を削除。
	- コードの可読性を向上させるために、変数名をより明確に変更。

- **テスト**
	- `RatedType` のバリデーション機能に関するテストスイートを導入。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->