### PR TITLE
crawlerのrequests配下でIDのValueObjectを利用するように変更

### DIFF
--- a/crawler/contest.go
+++ b/crawler/contest.go
@@ -11,6 +11,7 @@ import (
 	"github.com/meian/atgo/crawler/requests"
 	"github.com/meian/atgo/crawler/responses"
 	"github.com/meian/atgo/logs"
+	"github.com/meian/atgo/models/ids"
 	"github.com/meian/atgo/timezone"
 	"github.com/meian/atgo/url"
 	"github.com/pkg/errors"
@@ -61,7 +62,7 @@ func (c *Contest) Do(ctx context.Context, req requests.Contest) (*responses.Cont
 	}
 
 	return &responses.Contest{
-		ID:         req.ContestID,
+		ID:         ids.ContestID(req.ContestID),
 		Title:      title,
 		StartAt:    startAt,
 		Duration:   duration,

--- a/crawler/contest_archive.go
+++ b/crawler/contest_archive.go
@@ -12,6 +12,7 @@ import (
 	"github.com/meian/atgo/crawler/requests"
 	"github.com/meian/atgo/crawler/responses"
 	"github.com/meian/atgo/logs"
+	"github.com/meian/atgo/models/ids"
 	"github.com/meian/atgo/timezone"
 	"github.com/meian/atgo/url"
 	"github.com/meian/atgo/util"
@@ -171,7 +172,7 @@ func (c *ContestArchive) parseContest(ctx context.Context, tr *goquery.Selection
 	}
 
 	return responses.ContestArchive_Contest{
-		ID:         id,
+		ID:         ids.ContestID(id),
 		Title:      title,
 		StartAt:    startAt,
 		Duration:   duration,

--- a/crawler/contest_task.go
+++ b/crawler/contest_task.go
@@ -10,6 +10,7 @@ import (
 	"github.com/meian/atgo/crawler/requests"
 	"github.com/meian/atgo/crawler/responses"
 	"github.com/meian/atgo/logs"
+	"github.com/meian/atgo/models/ids"
 	"github.com/meian/atgo/url"
 	"github.com/meian/atgo/util"
 	"github.com/pkg/errors"
@@ -48,7 +49,7 @@ func (c *ContestTask) Do(ctx context.Context, req requests.ContestTask) (*respon
 	}
 
 	return &responses.ContestTask{
-		ContestID: req.ContestID,
+		ContestID: ids.ContestID(req.ContestID),
 		Tasks:     tasks,
 	}, nil
 }
@@ -111,7 +112,7 @@ func (c *ContestTask) parseTask(ctx context.Context, tr *goquery.Selection) (*re
 		return nil, errors.Wrap(err, "failed to parse memory limit")
 	}
 	return &responses.ContestTask_Task{
-		ID:        id,
+		ID:        ids.TaskID(id),
 		Index:     symbol,
 		Title:     title,
 		TimeLimit: sec,

--- a/crawler/responses/contest.go
+++ b/crawler/responses/contest.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Contest struct {
-	ID         string
+	ID         ids.ContestID
 	Title      string
 	StartAt    time.Time
 	Duration   time.Duration
@@ -17,7 +17,7 @@ type Contest struct {
 
 func (c Contest) ToModel() *models.Contest {
 	return &models.Contest{
-		ID:         ids.ContestID(c.ID),
+		ID:         c.ID,
 		Title:      c.Title,
 		StartAt:    c.StartAt,
 		Duration:   c.Duration,

--- a/crawler/responses/contest_archive.go
+++ b/crawler/responses/contest_archive.go
@@ -16,8 +16,8 @@ type ContestArchive struct {
 
 type ContestArchive_ContestList []ContestArchive_Contest
 
-func (c ContestArchive_ContestList) IDs() []string {
-	ids := make([]string, len(c))
+func (c ContestArchive_ContestList) IDs() []ids.ContestID {
+	ids := make([]ids.ContestID, len(c))
 	for i, contest := range c {
 		ids[i] = contest.ID
 	}
@@ -25,7 +25,7 @@ func (c ContestArchive_ContestList) IDs() []string {
 }
 
 type ContestArchive_Contest struct {
-	ID         string
+	ID         ids.ContestID
 	Title      string
 	StartAt    time.Time
 	Duration   time.Duration

--- a/crawler/responses/contest_archive.go
+++ b/crawler/responses/contest_archive.go
@@ -34,7 +34,7 @@ type ContestArchive_Contest struct {
 
 func (c ContestArchive_Contest) ToModel(ratedType *string) models.Contest {
 	return models.Contest{
-		ID:         ids.ContestID(c.ID),
+		ID:         c.ID,
 		RatedType:  null.StringFromPtr(ratedType),
 		Title:      c.Title,
 		StartAt:    c.StartAt,

--- a/crawler/responses/contest_task.go
+++ b/crawler/responses/contest_task.go
@@ -1,7 +1,6 @@
 package responses
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/meian/atgo/models"
@@ -9,22 +8,21 @@ import (
 )
 
 type ContestTask struct {
-	ContestID string
+	ContestID ids.ContestID
 	Tasks     []ContestTask_Task
 }
 
 func (ct ContestTask) ToModel() []models.ContestTask {
 	var tasks []models.ContestTask
 	for i, t := range ct.Tasks {
-		id := fmt.Sprintf("%s-%s", ct.ContestID, t.ID)
 		tasks = append(tasks, models.ContestTask{
-			ID:        ids.ContestTaskID(id),
-			ContestID: ids.ContestID(ct.ContestID),
-			TaskID:    ids.TaskID(t.ID),
+			ID:        ct.ContestID.ContestTaskID(t.ID),
+			ContestID: ct.ContestID,
+			TaskID:    t.ID,
 			Order:     i + 1,
 			Index:     t.Index,
 			Task: models.Task{
-				ID:        ids.TaskID(t.ID),
+				ID:        t.ID,
 				Title:     t.Title,
 				TimeLimit: t.TimeLimit,
 				Memory:    t.Memory,
@@ -35,7 +33,7 @@ func (ct ContestTask) ToModel() []models.ContestTask {
 }
 
 type ContestTask_Task struct {
-	ID        string
+	ID        ids.TaskID
 	Title     string
 	Index     string
 	TimeLimit time.Duration

--- a/crawler/responses/task.go
+++ b/crawler/responses/task.go
@@ -1,7 +1,9 @@
 package responses
 
+import "github.com/meian/atgo/models/ids"
+
 type Task struct {
-	ID        string
+	ID        ids.TaskID
 	Score     *int
 	Samples   []Task_Sample
 	CSRFToken string

--- a/crawler/task.go
+++ b/crawler/task.go
@@ -13,6 +13,7 @@ import (
 	"github.com/meian/atgo/crawler/responses"
 	"github.com/meian/atgo/csrf"
 	"github.com/meian/atgo/logs"
+	"github.com/meian/atgo/models/ids"
 	"github.com/meian/atgo/url"
 	"github.com/pkg/errors"
 )
@@ -59,7 +60,7 @@ func (c *Task) Do(ctx context.Context, req requests.Task) (*responses.Task, erro
 	}
 
 	return &responses.Task{
-		ID:        req.TaskID,
+		ID:        ids.TaskID(req.TaskID),
 		Score:     score,
 		Samples:   samples,
 		CSRFToken: csrf.FromDocument(doc),

--- a/crawler/task.go
+++ b/crawler/task.go
@@ -136,7 +136,7 @@ func (c *Task) parseSamples(ctx context.Context, doc *goquery.Document) ([]respo
 	return samples, nil
 }
 
-func (c *Task) taskStatement(ctx context.Context, doc *goquery.Document) (*goquery.Selection, error) {
+func (c *Task) taskStatement(_ context.Context, doc *goquery.Document) (*goquery.Selection, error) {
 	// span.stmt がない場合もあるので、その場合は div.task-statement を対象にする
 	stmt := doc.Find("span.lang-ja")
 	if stmt.Length() == 0 {

--- a/models/ids/contest.go
+++ b/models/ids/contest.go
@@ -1,6 +1,9 @@
 package ids
 
-import "regexp"
+import (
+	"fmt"
+	"regexp"
+)
 
 const contestIDLabel = "contest ID"
 
@@ -21,4 +24,8 @@ func (id ContestID) Validate() error {
 		return newErrInvalidFormat(contestIDLabel, id)
 	}
 	return nil
+}
+
+func (id ContestID) ContestTaskID(taskID TaskID) ContestTaskID {
+	return ContestTaskID(fmt.Sprint(id, "--", taskID))
 }

--- a/models/ids/contest_task.go
+++ b/models/ids/contest_task.go
@@ -1,6 +1,8 @@
 package ids
 
-import "regexp"
+import (
+	"regexp"
+)
 
 const contestTaskIDLabel = "contest task ID"
 

--- a/models/ids/task.go
+++ b/models/ids/task.go
@@ -1,6 +1,9 @@
 package ids
 
-import "regexp"
+import (
+	"fmt"
+	"regexp"
+)
 
 const taskIDLabel = "task ID"
 
@@ -21,4 +24,8 @@ func (id TaskID) Validate() error {
 		return newErrInvalidFormat(taskIDLabel, id)
 	}
 	return nil
+}
+
+func (id TaskID) TaskSampleID(index int) TaskSampleID {
+	return TaskSampleID(fmt.Sprint(id, "__", index))
 }

--- a/usecase/contest_load.go
+++ b/usecase/contest_load.go
@@ -45,13 +45,9 @@ func (u ContestLoad) Run(ctx context.Context, param ContestLoadParam) (*ContestL
 		return nil, errors.New("failed to list contests")
 	}
 
-	contestIDs := res.Contests.IDs()
-	if len(contestIDs) == 0 {
+	cids := res.Contests.IDs()
+	if len(cids) == 0 {
 		return nil, errors.New("no archived contests.")
-	}
-	cids := make([]ids.ContestID, len(contestIDs))
-	for i, id := range contestIDs {
-		cids[i] = ids.ContestID(id)
 	}
 	logger = logger.With("totalPages", res.TotalPages)
 	crepo := repo.NewContest(database.FromContext(ctx))
@@ -73,7 +69,7 @@ func (u ContestLoad) Run(ctx context.Context, param ContestLoadParam) (*ContestL
 		if !ok {
 			logger.Debug("new contest")
 			newContests = append(newContests, models.Contest{
-				ID:         ids.ContestID(contest.ID),
+				ID:         contest.ID,
 				Title:      contest.Title,
 				StartAt:    contest.StartAt,
 				Duration:   contest.Duration,

--- a/usecase/contest_load.go
+++ b/usecase/contest_load.go
@@ -60,8 +60,8 @@ func (u ContestLoad) Run(ctx context.Context, param ContestLoadParam) (*ContestL
 		logger.Error(err.Error())
 		return nil, errors.New("failed to find contests")
 	}
-	contestm := util.ToMap(contests, func(c models.Contest) string {
-		return string(c.ID)
+	contestm := util.ToMap(contests, func(c models.Contest) ids.ContestID {
+		return c.ID
 	})
 
 	ratedType := param.RatedType.String()

--- a/usecase/submit.go
+++ b/usecase/submit.go
@@ -168,7 +168,7 @@ func (u Submit) build(ctx context.Context) error {
 	return nil
 }
 
-func (u Submit) test(ctx context.Context) error {
+func (u Submit) test(context.Context) error {
 	cmd := exec.Command("go", "test")
 	cmd.Dir = workspace.Dir()
 	// テストの構文エラーはstderrで捕捉、テスト自体の失敗はstdoutで捕捉

--- a/usecase/task.go
+++ b/usecase/task.go
@@ -175,9 +175,9 @@ func (u Task) loadTaskSamples(ctx context.Context, contestID string, task *model
 	for i, s := range res.Samples {
 		index := i + 1
 		sample := models.TaskSample{
-			ID:     ids.TaskSampleID(fmt.Sprintf("%s_%d", task.ID, index)),
+			ID:     task.ID.TaskSampleID(index),
 			TaskID: task.ID,
-			Index:  fmt.Sprint(i + 1),
+			Index:  fmt.Sprint(index),
 			Type:   models.TaskSampleTypeSystem,
 			Input:  s.Input,
 			Output: s.Output,


### PR DESCRIPTION
requests構造体に含まれるIDをVallueObjectで定義するようにしました。  
responsesやcrawler本体まで含めると修正ボリュームが増えるので、別のPRで対応します。

それと合わせていくつか整理しています。

- 引数を渡しているが未使用のものを無名化した
    - contextの引数
    - 今後使う可能性もあるので削除でなく無名にした
- 不要なキャスト処理の削除
    - 一部のIDをVOにしたことでキャストが不要になった箇所があるので、それらのキャスト処理を削除

@coderabbitai  
修正内容に問題があるか、↑の内容とずれている箇所があるか確認をお願いします。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - コンテストとタスクIDの処理を改善し、型安全性を向上。
  - 新しいID生成メソッドを追加し、関連データの整理を強化。

- **バグ修正**
  - エラーメッセージを簡略化し、読みやすさを向上。

- **ドキュメント**
  - コードの可読性を向上させるためのインポート整理。

- **リファクタリング**
  - 不要な型変換を削除し、処理を簡素化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->