### PR TITLE
crawlerのrequests配下でIDのValueObjectを利用するように変更

### DIFF
--- a/crawler/contest.go
+++ b/crawler/contest.go
@@ -36,7 +36,7 @@ func (c *Contest) Do(ctx context.Context, req requests.Contest) (*responses.Cont
 	)
 	ctx = logs.ContextWith(ctx, logger)
 
-	crawler := c.crawler.WithPathParam("contestID", req.ContestID)
+	crawler := c.crawler.WithPathParam("contestID", string(req.ContestID))
 	doc, err := crawler.DocumentGet(ctx, nil)
 	if err != nil {
 		logger.Error(err.Error())

--- a/crawler/contest_task.go
+++ b/crawler/contest_task.go
@@ -35,7 +35,7 @@ func (c *ContestTask) Do(ctx context.Context, req requests.ContestTask) (*respon
 	)
 	ctx = logs.ContextWith(ctx, logger)
 
-	crawler := c.crawler.WithPathParam("contestID", req.ContestID)
+	crawler := c.crawler.WithPathParam("contestID", string(req.ContestID))
 	doc, err := crawler.DocumentGet(ctx, nil)
 	if err != nil {
 		logger.Error(err.Error())

--- a/crawler/requests/contest.go
+++ b/crawler/requests/contest.go
@@ -1,12 +1,11 @@
 package requests
 
+import "github.com/meian/atgo/models/ids"
+
 type Contest struct {
-	ContestID string
+	ContestID ids.ContestID
 }
 
 func (r Contest) Validate() error {
-	if r.ContestID == "" {
-		return ErrReqContestID
-	}
-	return nil
+	return r.ContestID.Validate()
 }

--- a/crawler/requests/contest_task.go
+++ b/crawler/requests/contest_task.go
@@ -1,12 +1,11 @@
 package requests
 
+import "github.com/meian/atgo/models/ids"
+
 type ContestTask struct {
-	ContestID string
+	ContestID ids.ContestID
 }
 
 func (r ContestTask) Validate() error {
-	if r.ContestID == "" {
-		return ErrReqContestID
-	}
-	return nil
+	return r.ContestID.Validate()
 }

--- a/crawler/requests/errors.go
+++ b/crawler/requests/errors.go
@@ -6,8 +6,6 @@ import (
 )
 
 var (
-	ErrReqContestID  = newRequiredError("Contest ID")
-	ErrReqTaskID     = newRequiredError("Task ID")
 	ErrReqSourceCode = newRequiredError("Source code")
 	ErrReqCSRFToken  = newRequiredError("CSRF token")
 

--- a/crawler/requests/submit.go
+++ b/crawler/requests/submit.go
@@ -4,22 +4,23 @@ import (
 	"net/url"
 
 	"github.com/meian/atgo/constant"
+	"github.com/meian/atgo/models/ids"
 )
 
 type Submit struct {
-	ContestID  string
-	TaskID     string
+	ContestID  ids.ContestID
+	TaskID     ids.TaskID
 	LanguageID constant.LanguageID
 	SourceCode string
 	CSRFToken  string
 }
 
 func (r Submit) Validate() error {
-	if r.ContestID == "" {
-		return ErrReqContestID
+	if err := r.ContestID.Validate(); err != nil {
+		return err
 	}
-	if r.TaskID == "" {
-		return ErrReqTaskID
+	if err := r.TaskID.Validate(); err != nil {
+		return err
 	}
 	if !r.LanguageID.Valid() {
 		return ErrInvalidLanguageID(r.LanguageID)
@@ -35,7 +36,7 @@ func (r Submit) Validate() error {
 
 func (r Submit) URLValues() url.Values {
 	return url.Values{
-		"data.TaskScreenName": {r.TaskID},
+		"data.TaskScreenName": {string(r.TaskID)},
 		"data.LanguageId":     {r.LanguageID.StringValue()},
 		"sourceCode":          {r.SourceCode},
 		"csrf_token":          {r.CSRFToken},

--- a/crawler/requests/task.go
+++ b/crawler/requests/task.go
@@ -1,16 +1,15 @@
 package requests
 
+import "github.com/meian/atgo/models/ids"
+
 type Task struct {
-	ContestID string
-	TaskID    string
+	ContestID ids.ContestID
+	TaskID    ids.TaskID
 }
 
 func (r Task) Validate() error {
-	if r.ContestID == "" {
-		return ErrReqContestID
+	if err := r.ContestID.Validate(); err != nil {
+		return err
 	}
-	if r.TaskID == "" {
-		return ErrReqTaskID
-	}
-	return nil
+	return r.TaskID.Validate()
 }

--- a/crawler/submit.go
+++ b/crawler/submit.go
@@ -25,7 +25,7 @@ func (c *Submit) Do(ctx context.Context, req requests.Submit) (*responses.Submit
 		return nil, err
 	}
 	logger := logs.FromContext(ctx)
-	crawler := c.crawler.WithPathParam("contestID", req.ContestID)
+	crawler := c.crawler.WithPathParam("contestID", string(req.ContestID))
 	resp, err := crawler.Post(ctx, nil, req)
 	if err != nil {
 		logger.Error(err.Error())

--- a/crawler/task.go
+++ b/crawler/task.go
@@ -39,8 +39,8 @@ func (c *Task) Do(ctx context.Context, req requests.Task) (*responses.Task, erro
 	ctx = logs.ContextWith(ctx, logger)
 
 	crawler := c.crawler.
-		WithPathParam("contestID", req.ContestID).
-		WithPathParam("id", req.TaskID)
+		WithPathParam("contestID", string(req.ContestID)).
+		WithPathParam("id", string(req.TaskID))
 	doc, err := crawler.DocumentGet(ctx, nil)
 	if err != nil {
 		logger.Error(err.Error())

--- a/usecase/contest.go
+++ b/usecase/contest.go
@@ -9,6 +9,7 @@ import (
 	"github.com/meian/atgo/http"
 	"github.com/meian/atgo/logs"
 	"github.com/meian/atgo/models"
+	"github.com/meian/atgo/models/ids"
 	"github.com/meian/atgo/repo"
 	"github.com/meian/atgo/usecase/common"
 	"github.com/meian/atgo/workspace"
@@ -84,7 +85,7 @@ func (u Contest) Run(ctx context.Context, param ContestParam) (*ContestResult, e
 func (u Contest) createContest(ctx context.Context, contestID string) (*models.Contest, error) {
 	logger := logs.FromContext(ctx)
 	client := http.ClientFromContext(ctx)
-	req := requests.Contest{ContestID: contestID}
+	req := requests.Contest{ContestID: ids.ContestID(contestID)}
 	res, err := crawler.NewContest(client).Do(ctx, req)
 	if err != nil {
 		logger.Error(err.Error())
@@ -101,7 +102,7 @@ func (u Contest) createContest(ctx context.Context, contestID string) (*models.C
 func (u Contest) loadTasks(ctx context.Context, contest *models.Contest) error {
 	logger := logs.FromContext(ctx)
 	client := http.ClientFromContext(ctx)
-	req := requests.ContestTask{ContestID: string(contest.ID)}
+	req := requests.ContestTask{ContestID: contest.ID}
 	res, err := crawler.NewContestTask(client).Do(ctx, req)
 	if err != nil {
 		logger.Error(err.Error())

--- a/usecase/submit.go
+++ b/usecase/submit.go
@@ -113,8 +113,8 @@ func (u Submit) login(ctx context.Context, info models.TaskInfo) (bool, string, 
 	logger := logs.FromContext(ctx)
 	client := http.ClientFromContext(ctx)
 	req := requests.Task{
-		ContestID: string(info.ContestID),
-		TaskID:    string(info.TaskID),
+		ContestID: info.ContestID,
+		TaskID:    info.TaskID,
 	}
 	res, err := crawler.NewTask(client).Do(ctx, req)
 	if err != nil {
@@ -200,8 +200,8 @@ func (u Submit) submit(ctx context.Context, info *models.TaskInfo, source string
 	logger := logs.FromContext(ctx)
 	client := http.ClientFromContext(ctx)
 	req := requests.Submit{
-		ContestID:  string(info.ContestID),
-		TaskID:     string(info.TaskID),
+		ContestID:  info.ContestID,
+		TaskID:     info.TaskID,
 		LanguageID: constant.LanguageGo_1_20_6,
 		SourceCode: source,
 		CSRFToken:  csrfToken,

--- a/usecase/task.go
+++ b/usecase/task.go
@@ -163,7 +163,7 @@ func (u Task) createTask(ctx context.Context, contestID string, taskID string) (
 func (u Task) loadTaskSamples(ctx context.Context, contestID string, task *models.Task) error {
 	logger := logs.FromContext(ctx)
 	client := http.ClientFromContext(ctx)
-	req := requests.Task{TaskID: string(task.ID), ContestID: contestID}
+	req := requests.Task{TaskID: task.ID, ContestID: ids.ContestID(contestID)}
 	res, err := crawler.NewTask(client).Do(ctx, req)
 	if err != nil {
 		logger.Error(err.Error())


### PR DESCRIPTION
requests構造体に含まれるIDをValueObjectで定義するようにしました。  
crawler本体は別のPRで対応します。

それと合わせていくつか整理しています。

@coderabbitai  
修正内容に問題があるか、↑の内容とずれている箇所があるか確認をお願いします。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - コンテストIDとタスクIDフィールドの型を強化し、バリデーションロジックを改善しました。これにより、誤ったデータが処理されるリスクが低減します。

- **バグ修正**
  - コンテストIDの処理方法を変更し、型の安全性を向上させました。これにより、潜在的な型不一致エラーが防止されます。

- **ドキュメンテーション**
  - コード内のエラーハンドリングのロジックを整理し、必要なエラー変数を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->