### PR TITLE
crawlerでids.Validateの呼び出しと不要なキャストを削除した

### DIFF
--- a/crawler/contest.go
+++ b/crawler/contest.go
@@ -11,7 +11,6 @@ import (
 	"github.com/meian/atgo/crawler/requests"
 	"github.com/meian/atgo/crawler/responses"
 	"github.com/meian/atgo/logs"
-	"github.com/meian/atgo/models/ids"
 	"github.com/meian/atgo/timezone"
 	"github.com/meian/atgo/url"
 	"github.com/pkg/errors"
@@ -62,7 +61,7 @@ func (c *Contest) Do(ctx context.Context, req requests.Contest) (*responses.Cont
 	}
 
 	return &responses.Contest{
-		ID:         ids.ContestID(req.ContestID),
+		ID:         req.ContestID,
 		Title:      title,
 		StartAt:    startAt,
 		Duration:   duration,

--- a/crawler/submit.go
+++ b/crawler/submit.go
@@ -7,7 +7,6 @@ import (
 	"github.com/meian/atgo/crawler/requests"
 	"github.com/meian/atgo/crawler/responses"
 	"github.com/meian/atgo/logs"
-	"github.com/meian/atgo/models/ids"
 	"github.com/meian/atgo/url"
 	"github.com/pkg/errors"
 )
@@ -42,6 +41,6 @@ func (c *Submit) Do(ctx context.Context, req requests.Submit) (*responses.Submit
 	}
 	// TODO: URLが違う場合にログを出す
 	return &responses.Submit{
-		Submitted: resp.Request.URL.String() == url.MySubmissionURL(ids.ContestID(req.ContestID)),
+		Submitted: resp.Request.URL.String() == url.MySubmissionURL(req.ContestID),
 	}, nil
 }

--- a/crawler/task.go
+++ b/crawler/task.go
@@ -13,7 +13,6 @@ import (
 	"github.com/meian/atgo/crawler/responses"
 	"github.com/meian/atgo/csrf"
 	"github.com/meian/atgo/logs"
-	"github.com/meian/atgo/models/ids"
 	"github.com/meian/atgo/url"
 	"github.com/pkg/errors"
 )
@@ -60,7 +59,7 @@ func (c *Task) Do(ctx context.Context, req requests.Task) (*responses.Task, erro
 	}
 
 	return &responses.Task{
-		ID:        ids.TaskID(req.TaskID),
+		ID:        req.TaskID,
 		Score:     score,
 		Samples:   samples,
 		CSRFToken: csrf.FromDocument(doc),


### PR DESCRIPTION
crawler内で不要なキャストが残っていた箇所を削除し、IDを取得した際にids.Validateを呼び出して不正なIDが混ざらないようにしました。

@coderabbitai  
上記に対しておかしい修正があれば指摘してください

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- コンテストIDの処理が簡素化され、リクエストから直接取得されるようになりました。
	- タスクIDのバリデーションが追加され、エラーハンドリングが改善されました。
  
- **バグ修正**
	- コンテストオブジェクトのエラーハンドリングが明確になり、無効なコンテストパース時に`nil`を返すようになりました。 

- **ドキュメント**
	- 不要なインポート文が削除され、依存関係が減少しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->