### PR TITLE
usecase配下でIDのValueObjectを利用するように変更

### DIFF
--- a/cmd/contest.go
+++ b/cmd/contest.go
@@ -28,7 +28,7 @@ var contestCmd = &cobra.Command{
 		ctx = logs.ContextWith(ctx, logger)
 
 		p := usecase.ContestParam{
-			ContestID: contestID,
+			ContestID: ids.ContestID(contestID),
 		}
 		res, err := usecase.Contest{}.Run(ctx, p)
 		if err != nil {

--- a/cmd/task.go
+++ b/cmd/task.go
@@ -4,6 +4,7 @@ import (
 	"github.com/meian/atgo/io"
 	"github.com/meian/atgo/logs"
 	"github.com/meian/atgo/models"
+	"github.com/meian/atgo/models/ids"
 	"github.com/meian/atgo/tmpl"
 	"github.com/meian/atgo/usecase"
 	"github.com/pkg/errors"
@@ -28,8 +29,8 @@ var taskCmd = &cobra.Command{
 		}
 
 		p := usecase.TaskParam{
-			TaskID:      taskID,
-			ContestID:   taskFlag.contestID,
+			TaskID:      ids.TaskID(taskID),
+			ContestID:   ids.ContestID(taskFlag.contestID),
 			ShowSamples: taskFlag.showSamples,
 		}
 		res, err := usecase.Task{}.Run(ctx, p)

--- a/cmd/taskLocalInit.go
+++ b/cmd/taskLocalInit.go
@@ -42,8 +42,8 @@ Do not edit task-local.yaml manually as it is used when submitting code with ` +
 		}
 
 		p := usecase.TaskLocalInitParam{
-			ContestID: taskLocalInitFlag.contestID,
-			TaskID:    taskID,
+			ContestID: ids.ContestID(taskLocalInitFlag.contestID),
+			TaskID:    ids.TaskID(taskID),
 		}
 		res, err := usecase.TaskLocalInit{}.Run(cmd.Context(), p)
 		if err != nil {

--- a/usecase/common/resolve_task_info.go
+++ b/usecase/common/resolve_task_info.go
@@ -11,7 +11,7 @@ import (
 	"github.com/meian/atgo/workspace"
 )
 
-func ResolveTaskInfo(ctx context.Context, contestID, taskID string) (*models.TaskInfo, bool, error) {
+func ResolveTaskInfo(ctx context.Context, contestID ids.ContestID, taskID ids.TaskID) (*models.TaskInfo, bool, error) {
 	logger := logs.FromContext(ctx)
 	if len(taskID) > 0 {
 		logger = logger.With("taskID", taskID)
@@ -21,11 +21,13 @@ func ResolveTaskInfo(ctx context.Context, contestID, taskID string) (*models.Tas
 				logger.Error(err.Error())
 				return nil, false, errors.New("failed to detect contest ID from task ID")
 			}
-			contestID = string(cID)
+			contestID = cID
 		}
 	}
 
 	mustSave := false
+
+	// TODO: contestIDが渡されない場合のフローを簡略化できそうなので後で確認する
 
 	file, ok := workspace.TaskInfoFile()
 	logger = logger.With("info file", file)
@@ -42,7 +44,7 @@ func ResolveTaskInfo(ctx context.Context, contestID, taskID string) (*models.Tas
 			return nil, false, errors.New("failed to find task info file")
 		}
 		return &models.TaskInfo{
-			ContestID: ids.ContestID(contestID),
+			ContestID: contestID,
 			TaskID:    ids.TaskID(taskID),
 		}, true, nil
 	}
@@ -55,8 +57,8 @@ func ResolveTaskInfo(ctx context.Context, contestID, taskID string) (*models.Tas
 		return nil, false, errors.New("cannot get contest ID from task info file")
 	}
 	if len(contestID) > 0 {
-		if info.ContestID != ids.ContestID(contestID) {
-			info.ContestID = ids.ContestID(contestID)
+		if info.ContestID != contestID {
+			info.ContestID = contestID
 			info.TaskID = ids.TaskID(taskID)
 			mustSave = true
 		}

--- a/usecase/contest.go
+++ b/usecase/contest.go
@@ -19,7 +19,7 @@ import (
 type Contest struct{}
 
 type ContestParam struct {
-	ContestID string
+	ContestID ids.ContestID
 }
 type ContestResult struct {
 	Contest models.Contest
@@ -43,7 +43,7 @@ func (u Contest) Run(ctx context.Context, param ContestParam) (*ContestResult, e
 		return nil, errors.New("failed to find contest")
 	}
 	if contest == nil {
-		contest, err = u.createContest(ctx, string(info.ContestID))
+		contest, err = u.createContest(ctx, info.ContestID)
 		if err != nil {
 			return nil, err
 		}
@@ -61,7 +61,7 @@ func (u Contest) Run(ctx context.Context, param ContestParam) (*ContestResult, e
 		return nil, errors.New("failed to find contest with tasks")
 	}
 
-	if param.ContestID != string(info.ContestID) {
+	if param.ContestID != info.ContestID {
 		taskFile, _ := workspace.TaskInfoFile()
 		if err := info.WriteFile(taskFile); err != nil {
 			logger.Error(err.Error())
@@ -82,7 +82,7 @@ func (u Contest) Run(ctx context.Context, param ContestParam) (*ContestResult, e
 	}, nil
 }
 
-func (u Contest) createContest(ctx context.Context, contestID string) (*models.Contest, error) {
+func (u Contest) createContest(ctx context.Context, contestID ids.ContestID) (*models.Contest, error) {
 	logger := logs.FromContext(ctx)
 	client := http.ClientFromContext(ctx)
 	req := requests.Contest{ContestID: ids.ContestID(contestID)}

--- a/usecase/task.go
+++ b/usecase/task.go
@@ -21,8 +21,8 @@ import (
 type Task struct{}
 
 type TaskParam struct {
-	TaskID      string
-	ContestID   string
+	ContestID   ids.ContestID
+	TaskID      ids.TaskID
 	ShowSamples bool
 }
 
@@ -51,14 +51,14 @@ func (u Task) Run(ctx context.Context, param TaskParam) (*TaskResult, error) {
 		return nil, errors.New("failed to find task")
 	}
 	if task == nil {
-		task, err = u.createTask(ctx, string(info.ContestID), string(info.TaskID))
+		task, err = u.createTask(ctx, info.ContestID, info.TaskID)
 		if err != nil {
 			logger.Error(err.Error())
 			return nil, errors.New("failed to create task")
 		}
 	}
 	if !task.Loaded {
-		err := u.loadTaskSamples(ctx, string(info.ContestID), task)
+		err := u.loadTaskSamples(ctx, info.ContestID, task)
 		if err != nil {
 			return nil, err
 		}
@@ -70,7 +70,7 @@ func (u Task) Run(ctx context.Context, param TaskParam) (*TaskResult, error) {
 		return nil, errors.New("failed to find contest")
 	}
 	if contest == nil {
-		contest, err = (&Contest{}).createContest(ctx, string(info.ContestID))
+		contest, err = (&Contest{}).createContest(ctx, info.ContestID)
 		if err != nil {
 			logger.Error(err.Error())
 			return nil, errors.New("failed to create contest")
@@ -126,7 +126,7 @@ func (u Task) resolveTaskInfo(ctx context.Context, param TaskParam) (*models.Tas
 	return info, mustSave, nil
 }
 
-func (u Task) createTask(ctx context.Context, contestID string, taskID string) (*models.Task, error) {
+func (u Task) createTask(ctx context.Context, contestID ids.ContestID, taskID ids.TaskID) (*models.Task, error) {
 	logger := logs.FromContext(ctx)
 
 	ctx = logs.ContextWith(ctx, logger)
@@ -160,7 +160,7 @@ func (u Task) createTask(ctx context.Context, contestID string, taskID string) (
 	return task, nil
 }
 
-func (u Task) loadTaskSamples(ctx context.Context, contestID string, task *models.Task) error {
+func (u Task) loadTaskSamples(ctx context.Context, contestID ids.ContestID, task *models.Task) error {
 	logger := logs.FromContext(ctx)
 	client := http.ClientFromContext(ctx)
 	req := requests.Task{TaskID: task.ID, ContestID: ids.ContestID(contestID)}

--- a/usecase/task_local_init.go
+++ b/usecase/task_local_init.go
@@ -11,6 +11,7 @@ import (
 	"github.com/meian/atgo/io"
 	"github.com/meian/atgo/logs"
 	"github.com/meian/atgo/models"
+	"github.com/meian/atgo/models/ids"
 	"github.com/meian/atgo/tmpl"
 	"github.com/meian/atgo/workspace"
 	"github.com/pkg/errors"
@@ -19,13 +20,13 @@ import (
 type TaskLocalInit struct{}
 
 type TaskLocalInitParam struct {
-	TaskID    string
-	ContestID string
+	TaskID    ids.TaskID
+	ContestID ids.ContestID
 }
 
 type TaskLocalInitResult struct {
-	ContestID string
-	TaskID    string
+	ContestID ids.ContestID
+	TaskID    ids.TaskID
 	New       bool
 }
 
@@ -64,8 +65,8 @@ func (u TaskLocalInit) Run(ctx context.Context, param TaskLocalInitParam) (*Task
 			return nil, errors.New("failed to restore task files")
 		}
 		return &TaskLocalInitResult{
-			ContestID: string(contest.ID),
-			TaskID:    string(task.ID),
+			ContestID: contest.ID,
+			TaskID:    task.ID,
 			New:       false,
 		}, nil
 	}
@@ -137,8 +138,8 @@ func (u TaskLocalInit) Run(ctx context.Context, param TaskLocalInitParam) (*Task
 	}
 
 	return &TaskLocalInitResult{
-		ContestID: string(contest.ID),
-		TaskID:    string(task.ID),
+		ContestID: contest.ID,
+		TaskID:    task.ID,
 		New:       true,
 	}, nil
 }


### PR DESCRIPTION
usecase配下で使用するパラメータや引数に含まれるIDをValueObjectで定義するようにしました。  

@coderabbitai  
修正内容に問題があるか、↑の内容とずれている箇所があるか確認をお願いします。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- `ContestID`と`TaskID`の型を`ids`パッケージの特定タイプに変更し、型安全性を向上。
	- `ContestParam`や`TaskParam`構造体での`ContestID`と`TaskID`の処理を強化し、明確性を向上。

- **バグ修正**
	- 不要な型変換を排除し、パフォーマンスと可読性を改善。

- **ドキュメンテーション**
	- コードの整合性を確保し、データ処理の堅牢性を向上させるための変更が反映されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->